### PR TITLE
Fixing PPS Interrupt on Teensy

### DIFF
--- a/OnStep.ino
+++ b/OnStep.ino
@@ -671,6 +671,7 @@ void setup() {
 #if defined(__AVR__)
   attachInterrupt(PpsInt,ClockSync,RISING);
 #elif defined(__arm__) && defined(TEENSYDUINO)
+  pinMode(PpsPin, INPUT); // without this, interrupt seems not to work on teensy
   attachInterrupt(PpsPin,ClockSync,RISING);
 #endif
 #endif


### PR DESCRIPTION
The PPS Interrupt did not work on my Teensy. Teensyduino seems to need the explicit setting of pinMode to INPUT