### PR TITLE
Arduino mega2560 teensy3.1 alpha

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -158,6 +158,10 @@
 #define DE_MODE_GOTO_OFF             // programs the Dec uStep mode M0/M1/M2, used during gotos, optional and default _OFF. Other values 0 to 7 (0xb000 to 111)
 #define DE_STEP_GOTO 1               // 1=goto mode is same as normal mode: for example if normal tracking mode is 32x and goto is 8x this would be 4
 
+#if defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
+#define ETHERNET_USE_DHCP_OFF        // if DHCP is used to obtain the IP address
+#endif
+
 // THAT'S IT FOR USER CONFIGURATION!
 
 // -------------------------------------------------------------------------------------------------------------------------

--- a/EEPROM_LP.h
+++ b/EEPROM_LP.h
@@ -1,0 +1,37 @@
+/*
+  EEPROM.h - EEPROM library
+  Copyright (c) 2006 David A. Mellis.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  
+  // update added by Luka
+*/
+
+#ifndef EEPROM_h
+#define EEPROM_h
+
+#include <inttypes.h>
+
+class EEPROMClass
+{
+  public:
+    uint8_t read(int);
+    void write(int, uint8_t);
+    void update(int, uint8_t);
+};
+
+extern EEPROMClass EEPROM;
+
+#endif

--- a/EEPROM_LP.ino
+++ b/EEPROM_LP.ino
@@ -1,0 +1,79 @@
+/*
+  EEPROM.cpp - EEPROM library
+  Copyright (c) 2006 David A. Mellis.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/******************************************************************************
+ * Includes
+ ******************************************************************************/
+
+#include "Energia.h"
+#include "driverlib/eeprom.h"
+#include "EEPROM_LP.h"
+
+/******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/******************************************************************************
+ * Constructors
+ ******************************************************************************/
+
+/******************************************************************************
+ * User API
+ ******************************************************************************/
+#define BYTES_PER_WORD 	4
+#define WORDS_PER_BLOCK 16
+#define NUM_BLOCKS		32
+
+// TM4C1294 crashes if ROM_ calls are used??? Bug in Energia.
+
+uint8_t EEPROMClass::read(int address)
+{
+	uint32_t byteAddr = address - (address % BYTES_PER_WORD);
+	//int block = address / (BYTES_PER_WORD * WORDS_PER_BLOCK);
+	//int word = (address / BYTES_PER_WORD) % WORDS_PER_BLOCK;
+	uint32_t wordVal = 0;
+
+	EEPROMRead(&wordVal, byteAddr, 4);
+	wordVal = wordVal >> (8*(address % BYTES_PER_WORD));
+
+	return (uint8_t) wordVal;
+}
+
+void EEPROMClass::write(int address, uint8_t value)
+{
+	uint32_t byteAddr = address - (address % BYTES_PER_WORD);
+
+	uint32_t wordVal = 0;
+	EEPROMRead(&wordVal, byteAddr, 4);
+	wordVal &= ~(0xFF << (8*(address % BYTES_PER_WORD)));
+	wordVal += value << (8*(address % BYTES_PER_WORD));
+
+	EEPROMProgram(&wordVal, byteAddr, 4);
+}
+
+void EEPROMClass::update(int address, uint8_t value)
+{
+  	uint8_t old_value = read(address);
+  
+	if(value != old_value)
+		write(address, value);
+}
+
+EEPROMClass EEPROM;
+ 

--- a/Library.ino
+++ b/Library.ino
@@ -7,6 +7,10 @@ Library::Library()
   
   #if defined(TEENSYDUINO) && !defined(E2END)
   #define E2END 2047
+  #elif defined(__TM4C123GH6PM__) || defined(__LM4F120H5QR__)
+  #define E2END 2047
+  #elif defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
+  #define E2END 6143
   #endif
   byteMax=E2END;                       // default=4095 (or 2047 on Teensy3.1)
 

--- a/Network.ino
+++ b/Network.ino
@@ -1,0 +1,67 @@
+#if defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
+
+// provice the same functions as for serial
+
+// Enter a MAC address and IP address for your controller below. MAC address will be on the sticker on the Tiva Connected Launchpad.
+// The IP address will be dependent on your local network.
+// gateway and subnet are optional:
+byte mac[] = {
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+};
+IPAddress ip(192, 168, 1, 55);
+IPAddress myDns(192,168,1, 1);
+IPAddress gateway(192, 168, 1, 1);
+IPAddress subnet(255, 255, 255, 0);
+
+
+// Network server port
+EthernetServer server(9999);
+EthernetClient client;
+boolean alreadyConnected = false; // whether or not the client was connected previously
+
+
+void Ethernet_Init() {
+  // initialize the ethernet device
+#if defined(ETHERNET_USE_DHCP)
+  Ethernet.begin(mac);
+#else
+  Ethernet.begin(mac, ip, myDns, gateway, subnet);
+#endif
+
+  server.begin();
+}
+
+void Ethernet_send(const char data[]) {
+  if (!client)
+   return;
+   
+  client.flush();
+   
+  client.print(data);
+  do {} while (Serial_transmit());
+}
+
+void Ethernet_print(const char data[]) {
+  if (!client)
+   return;
+   
+   server.print(data);
+ }
+ 
+ boolean Ethernet_transmit() {
+   return false;
+ }
+ 
+ boolean Ethernet_available() {
+   client = server.available();
+   return client;
+ }
+ 
+ char Ethernet_read() {
+   if (!client)
+   return -1;
+   
+   return client.read();
+ }
+#endif
+

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -1303,8 +1303,10 @@ void setup() {
   Serial1_Init(9600);
   Serial_Init(9600); // for Tiva TM4C the serial is redirected to serial5 in serial.ino file
 
+#if defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
   // get ready for Ethernet communications
   Ethernet_Init();
+#endif
   
   // get the site information, if a GPS were attached we would use that here instead
   currentSite=EEPROM.read(EE_currentSite);  if (currentSite>3) currentSite=0; // site index is valid?

--- a/Serial.ino
+++ b/Serial.ino
@@ -130,6 +130,35 @@ char Serial1_read()
 
 #else  // on non-AVR platforms, try to use the built-in serial stuff...
 
+#if defined(__TM4C123GH6PM__) || defined(__LM4F120H5QR__) || defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
+// use serial5 as serial (serial0) is connected to the debugger/programming chip
+// if you really want to use serial you will need to do some soldering
+void Serial_Init(unsigned int baud) {
+  Serial5.begin(baud);
+}
+
+void Serial_send(const char data[]) {
+  Serial5.print(data);
+  do {} while (Serial_transmit());
+}
+
+void Serial_print(const char data[]) {
+  Serial5.print(data);
+}
+
+boolean Serial_transmit() {
+  return false;
+}
+
+boolean Serial_available() {
+  return Serial5.available();
+}
+
+char Serial_read() {
+  return Serial5.read();
+}
+
+#else
 void Serial_Init(unsigned int baud) {
   Serial.begin(baud);
 }
@@ -154,7 +183,37 @@ boolean Serial_available() {
 char Serial_read() {
   return Serial.read();
 }
+#endif
 
+#if defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
+// use serial7 as serial1 (serial1) as serial1 is not readily available on the board
+// if you really want to use serial1 you will need to do some soldering
+void Serial1_Init(unsigned int baud) {
+  Serial7.begin(baud);
+}
+
+void Serial1_send(const char data[])
+{
+  Serial1_print(data);
+  do {} while (Serial1_transmit());
+}
+
+void Serial1_print(const char data[]) {
+  Serial7.print(data);
+}
+
+boolean Serial1_transmit() {
+  return false;
+}
+
+boolean Serial1_available() {
+  return Serial7.available();
+}
+
+char Serial1_read() {
+  return Serial7.read();
+}
+#else
 void Serial1_Init(unsigned int baud) {
   Serial1.begin(baud);
 }
@@ -180,5 +239,6 @@ boolean Serial1_available() {
 char Serial1_read() {
   return Serial1.read();
 }
+#endif
 
 #endif


### PR DESCRIPTION
Added support for TI Tiva Launchpad TM4C123 and TI Tiva Connected Launchpad TM4C129
Added Ethernet for the Connected Launchpad

Some things require clarifications:
1. Most of the new code is within the newly added
#if defined(__TM4C123GH6PM__) || defined(__LM4F120H5QR__)
and
#if defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
each for one of the two Launchpads (the TM4C123 was released in two revisions).

My changes should not affect any of the code Arduino/Teensy, however, read carefully point 7 below before trying to compile.

2. Wherever possible I have shared the code with Teensy. For example, all timer calculations are using the Teensy code. The major difference is how timers are configured and started for the two devices. Energia does not support IntervalTimer so all timers are configured manually, similarly to the ATmega.
There are lots of new "#if defined" in OnStep.ino and Timer.ino :-)

3. Ethernet code is all new, of course. I could test it only by using a telnet client and it seems to work fine. DHCP or static IP is supported.
Does anybody know any software that I can use with the direct IP connection?
The OnStep android app does not support Ethernet and neither does the OnStep ASCOM driver.

4. Both Launchpads cannot use serial 0 as it is used for debugging/programming. I had to redirect this to serial5 for both Launchpads. Arduino/Teensy should not be affected.

5. Also the Connected Launchpad does not seem to have pins for serial1 broken out (not sure why) so I redirected this to serial7, only for this Launchpad. Again Arduino/Teensy should not be affected.


Now this is where it gets complicated. I had to work around bugs in Arduino and the missing code in Energia (TI Launchpads use Energia which is an Arduino clone).

6. The standard Energia did not have EEPROM.update method, only read and write methods. OnStep uses the EEPROM.update extensively. So I have written the EEPROM.update method and added it to Energia. The Energia github master branch already has my change (pull #812), however, the Energia installer is using the older code and does not have the EEPROM.update and hence it won't work without modifications.

So... the OnStep folder has two new files, EEPROM_LP.h and EEPROM_LP.ino. People can either update the Energia source with these files or just use these files when compiling. 
All they need to do is to comment out either "#include EEPROM.h" (for Tiva devices) or to comment out "#include EEPROM_LP.h" for Arduino/Teensy.

Once Energia installer gets patched EEPROM_LP.h and EEPROM_LP.ino can be removed from the code.

7. Arduino (and Energia) have a bug when creating a list of libraries for the linker. Basically all #include files are used to create this list and pre-processor directives are ignored. For example:
#ifdef A
#include "A.h"
#else
#include "B.h"
#endif
will include both A and B libraries. Things have been like this for few years but apparently a fix is finally on its way.

In our case the bug means that in
#if defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
#include "Ethernet.h"
#endif
the Ethernet.h will ALWAYS be included. This will of course cause compiler errors on every device apart from the Connected Launchpad as they don't have Ethernet. There are few more Launchpad specific #include files.

So, it is necessary to manually comment out header files that are not used. They are clearly separated in the OnStep.ino file.

8. I had to work around few more bugs in Energia but they are quite simple and explained in the code. Nothing to worry about here.


Hope this all makes sense. Things would have been much easier if Arduino/Energia were bug-free.

Cheers
Luka