### PR TITLE
Fix <ACK> command from Serial1.

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -1262,9 +1262,9 @@ boolean buildCommand_serial_one(char c) {
   // (chr)6 is a special status command for the LX200 protocol
   if ((c==(char)6) && (bufferPtr_serial_one==0)) {
     #ifdef MOUNT_TYPE_ALTAZM
-    Serial_print("A");
+    Serial1_print("A");
     #else
-    Serial_print("P");
+    Serial1_print("P");
     #endif
   }
 


### PR DESCRIPTION
This fixes the issue of the OnStep INDI driver not being able to connect when using the Serial 1 interface (usually bluetooth). The problem is described in the INDI forum at http://www.indilib.org/forum/wish-list/1406-driver-onstep-lx200-like-for-indi.html?start=18.

Thanks,
Ben