### PR TITLE
Add support for LX200 Set current site longitude without sign (:SgDDD*MM#)

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -964,9 +964,24 @@ void processCommands() {
       if (command[1]=='d')  { if (!dmsToDouble(&newTargetDec,parameter,true)) commandError=true; } else 
 //  :SgsDDD*MM#
 //          Set current sites longitude to sDDD*MM an ASCII position string, East longitudes are expressed as negative
+//  :SgDDD*MM#
+//          Set current sites longitude to DDD*MM an ASCII position string. East longitudes are expressed as 360 - (longitude East).
 //          Return: 0 on failure
 //                  1 on success
-      if (command[1]=='g')  { i=highPrecision; highPrecision=false; if (!dmsToDouble(&longitude,(char *)&parameter[1],false)) commandError=true; else { if (parameter[0]=='-') longitude=-longitude; EEPROM_writeFloat(EE_sites+(currentSite)*25+4,longitude); } update_lst(jd2last(JD,UT1)); highPrecision=i; } else 
+      if (command[1]=='g')  { 
+            i=highPrecision; 
+            highPrecision=false; 
+            if ((parameter[0] == '-') || (parameter[0] == '+')) {
+                if (!dmsToDouble(&longitude,(char *)&parameter[1],false)) commandError=true; 
+            } else {
+                if (!dmsToDouble(&longitude,(char *)&parameter[0],false)) commandError=true; 
+            }
+            if (commandError == false) {
+                  if (parameter[0]=='-') longitude=-longitude; 
+                  EEPROM_writeFloat(EE_sites+(currentSite)*25+4,longitude); 
+            } 
+            update_lst(jd2last(JD,UT1)); highPrecision=i; 
+      } else 
 //  :SGsHH#
 //  :SGsHH:MM# (where MM is 30 or 45)
 //          Set the number of hours added to local time to yield UTC


### PR DESCRIPTION
This change implements the :SgDDD_MM# set current site longitude command as described by the LX200 protocol. It should allow the :SgsDDD_MM# functionality to work as before.

This change was made so that the OnStep INDI driver could use common LX200 driver code as-is. /cc @azwing since he made a modification to the INDI driver code to support the signed set site longitude.
