### PR TITLE
Change the configuration system so only one change is needed

### DIFF
--- a/Config.Classic.h
+++ b/Config.Classic.h
@@ -13,6 +13,8 @@
 #define Classic_OFF   //  <- Turn _ON to use this configuration
 
 #ifdef Classic_ON
+
+#define BOARD_SELECTED
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/Config.MaxPCB.h
+++ b/Config.MaxPCB.h
@@ -12,6 +12,8 @@
 #define MaxPCB_OFF   //  <- Turn _ON to use this configuration
 
 #ifdef MaxPCB_ON
+
+#define BOARD_SELECTED
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/Config.Mega2560Alt.h
+++ b/Config.Mega2560Alt.h
@@ -12,6 +12,8 @@
 #define Mega2560Alt_OFF   //  <- Turn _ON to use this configuration
 
 #ifdef Mega2560Alt_ON
+
+#define BOARD_SELECTED
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/Config.MiniPCB.h
+++ b/Config.MiniPCB.h
@@ -12,6 +12,8 @@
 #define MiniPCB_OFF   //  <- Turn _ON to use this configuration
 
 #ifdef MiniPCB_ON
+
+#define BOARD_SELECTED
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/Config.Ramps14.h
+++ b/Config.Ramps14.h
@@ -18,6 +18,8 @@
 #define Ramps14_OFF   //  <- turn _ON to use this configuration
 
 #ifdef Ramps14_ON
+
+#define BOARD_SELECTED
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/Config.TM4C.h
+++ b/Config.TM4C.h
@@ -12,6 +12,8 @@
 #define Launchpad_OFF   //  <- Turn _ON to use this configuration
 
 #ifdef Launchpad_ON
+
+#define BOARD_SELECTED
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -62,7 +62,7 @@
 #include "Config.Ramps14.h"
 #include "Config.Mega2560Alt.h"
 
-#if !defined(Classic_ON) && !defined(MiniPCB_ON) && !defined(MaxPCB_ON) && !defined(TM4C_ON) && !defined(Ramps14_ON) && !defined(Mega2560Alt_ON)
+#if !defined(BOARD_SELECTED)
   #error "Choose ONE Config.xxxxx.h file and enable it for use by turning it _ON."
 #endif
 

--- a/Pins.Ramps14.h
+++ b/Pins.Ramps14.h
@@ -24,7 +24,7 @@
 #define PpsPin         2    //
 #define PpsInt         0    // Interrupt 0 on Pin 2
 
-// Pins to Axis2 Dec/Alt on RAMPS X
+// Pins to Axis1 RA/Az on RAMPS X
 #define Axis1DirPin   55    // Pin A1 (Dir)
 #define Axis1DirBit    1    //
 #define Axis1DirPORT  PORTF //


### PR DESCRIPTION
This change to the configuration system makes it simpler to maintain OnStep in the future. 

A new board config should not require multiple changes to OnStep.ino, only an include for the new Config.x.h file.

For the end user, they only have to change one file (Config.x.h) to modify _OFF to _ON.

Also a typo fix in Pins.x.h for RAMPS 1.4.