### PR TITLE
Constants.h include file should be included only once

### DIFF
--- a/Config.STM32.h
+++ b/Config.STM32.h
@@ -1,70 +1,209 @@
-// === CONFIGURATION START
-// This configuration was generated using OnStepConfigGen.py
-// On: 2018-01-06 15:43
-#define STM32_ON
-#ifdef  STM32_ON
-#define MOUNT_TYPE_GEM
-#define StepsPerDegreeAxis1        20480.0
-#define StepsPerWormRotationAxis1  51200.0
-#define AXIS1_DRIVER_MODEL         LV8729
-#define AXIS1_MICROSTEPS           64
-#define AXIS1_MICROSTEPS_GOTO      2
-#define AXIS1_STEP_GOTO            2
+// -----------------------------------------------------------------------------------
+// Configuration for OnStep on the STM32F103V and STM32F103Z (the faster STM32F407 has no EEPROM support at present)
 
-#define StepsPerDegreeAxis2        20480.0
-#define StepsPerWormRotationAxis2  51200.0
-#define AXIS2_DRIVER_MODEL         LV8729
-#define AXIS2_MICROSTEPS           64
-#define AXIS2_MICROSTEPS_GOTO      2
-#define AXIS2_STEP_GOTO            2
+/*
+ * For more information on setting OnStep up see http://www.stellarjourney.com/index.php?r=site/equipment_onstep and 
+ * join the OnStep Groups.io at https://groups.io/g/onstep
+ * 
+ * See the Pins.STM32.h file for detailed information on this pin map to be sure it matches your wiring *** USE AT YOUR OWN RISK ***
+ *
+*/
 
-#define MaxRate                    16
-#define PECBufferSize              600
+#define STM32_OFF   //  <- Turn _ON to use this configuration
 
-#define MODE_SWITCH_BEFORE_SLEW_ON
+#ifdef STM32_ON
+// -------------------------------------------------------------------------------------------------------------------------
+// ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
+
+// Enables internal goto assist mount modeling (for Eq mounts), default=OFF (Experimental)
+// Note that Goto Assist in Sky Planetarium works even if this is off
 #define ALIGN_GOTOASSIST_ON
-#define TRACK_REFRACTION_RATE_DEFAULT_ON
-#define REMEMBER_MAX_RATE_ON
 
-// The following are less common options. Edit them by hand for now.
-#define AXIS1_FAULT_OFF
-#define AXIS2_FAULT_OFF
+// Default speed for Serial1 com port, Default=9600
 #define SERIAL1_BAUD_DEFAULT 9600
-#define SERIAL4_BAUD_DEFAULT 9600
+
+// ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01
+// Pin ? (Aux1) for GPIO0 and Pin ? (Aux2) for Rst control.  Choose only one feature on Aux1/2.
 #define ESP8266_CONTROL_OFF
+
+// Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
+// _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)
+#define MOUNT_TYPE_GEM
+
+// Strict parking, default=OFF.  Set to ON and unparking is only allowed if successfully parked.  Otherwise unparking is allowed if at home and not parked (the Home/Reset command ":hF#" sets this state.) 
 #define STRICT_PARKING_OFF
+
+// ST4 interface on pins ?, ?, ?, ?.  Pin ? is RA- (West), Pin ? is Dec- (South), Pin ? is Dec+ (North), Pin ? is RA+ (East.)
+// ST4_ON enables the interface, ST4_PULLUP enables the interface and any internal pullup resistors.
+// It is up to you to create an interface that meets the electrical specifications of any connected device, use at your own risk.  Default=OFF
 #define ST4_OFF
+// If SEPARATE_PULSE_GUIDE_RATE_ON is used the ST4 port is limited to guide rates <= 1X except when ST4_HAND_CONTROL_ON is used.
+// Additionally, ST4_HAND_CONTROL_ON enables special features: Press and hold [E]+[W] buttons for > 2 seconds...  In this mode [E] decreases and [W] increases guide rates (or if tracking isn't on yet adjusts illuminated recticule brightness.)
+// [S] for Sync (or Accept if in align mode.) [N] for Tracking on/off. -OR- Press and hold [N]+[S] buttons for > 2 seconds...  In this mode [E] selects prior and [W] next user catalog item.
+// [N] to do a Goto to the catalog item.  [S] for Sound on/off.  The keypad returns to normal operation after 4 seconds of inactivity.  ST4_HAND_CONTROL_ON also adds a 100ms de-bounce to all button presses.
+// Finally, during a goto pressing any button aborts the slew.  If meridian flip paused at home, pressing any button continues.
 #define ST4_HAND_CONTROL_ON
+
+// Separate pulse-guide rate so centering and guiding don't disturb each other, default=ON
 #define SEPARATE_PULSE_GUIDE_RATE_ON
+
+// Guide time limit (in seconds,) default=0 (no limit.)  A safety feature, some guides are started with one command and stopped with another.  
+// If the stop command is never received the guide will continue forever unless this is enabled.
 #define GUIDE_TIME_LIMIT 0
-#define RTC_OFF
+
+// PPS use _ON or _PULLUP to enable the input and use the built-in pullup resistor.  Sense rising edge on Pin ? for optional precision clock source (GPS, for example), default=OFF [infrequently used option]
 #define PPS_SENSE_OFF
+
+// PEC sense on Pin ? use _ON or _PULLUP to enable the input/use the built-in pullup resistor (digital input) or provide a comparison value (see below) for analog operation, default=OFF
+// Analog values range from 0 to 1023 which indicate voltages from 0-3.3VDC on the analog pin, for example "PEC_SENSE 600" would detect an index when the voltage exceeds 1.93V
+// With either index detection method, once triggered 60s must expire before another detection can happen.  This gives time for the index magnet to pass by the detector before another cycle begins.
+// Ignored on Alt/Azm mounts.
 #define PEC_SENSE_OFF
+// PEC sense, rising edge (default with PEC_SENSE_STATE HIGH, use LOW for falling edge, ex. PEC_SENSE_ON) ; for optional PEC index
 #define PEC_SENSE_STATE HIGH
+
+// Switch close (to ground) on Pin ? for optional limit sense (stops gotos and/or tracking), default=OFF
 #define LIMIT_SENSE_OFF
-#define STATUS_LED_PINS_ON
+
+// Light status LED by sink to ground (Pin ?), default=ON.
+// _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash
+#define STATUS_LED_PINS_OFF
+// Light 2nd status LED by sink to ground (Pin ?), default=OFF.
+// _ON sets this to blink at 1 sec intervals when PPS is synced.  Turns off if tracking is stopped.  Turns on during gotos.
 #define STATUS_LED2_PINS_OFF
+// Light reticule LED by sink to ground (Pin ?), default=OFF.  (don't use with STATUS_LED2_PINS_ON)
+// RETICULE_LED_PINS n, where n=0 to 255 activates this feature and sets default brightness
 #define RETICULE_LED_PINS_OFF
+
+// Sound/buzzer on Pin ?, default=OFF.
+// Specify frequency for a piezo speaker (for example "BUZZER 2000") or use BUZZER_ON for a piezo buzzer.
 #define BUZZER_OFF
+// Sound state at startup, default=ON.
 #define DEFAULT_SOUND_ON
-#define REMEMBER_AUTO_MERIDIAN_FLIP_OFF
-#define REMEMBER_PAUSE_HOME_OFF
-#define REVERSE_AXIS1_OFF
-#define REVERSE_AXIS2_OFF
-#define DegreesForAcceleration   5.0
-#define DegreesForRapidStop      1.0
-#define BacklashTakeupRate        25
-#define MinutesPastMeridianE      60
-#define MinutesPastMeridianW      60
-#define UnderPoleLimit            12
-#define MinDec                   -91
-#define MaxDec                   +91
-#define MaxAzm                   180
+
+// Optionally adjust tracking rate to compensate for atmospheric refraction, default=OFF
+// can be turned on/off with the :Tr# and :Tn# commands regardless of this setting
+#define TRACK_REFRACTION_RATE_DEFAULT_ON
+
+// Set to ON and OnStep will remember the last auto meridian flip setting (on/off), default=OFF
+#define REMEMBER_AUTO_MERIDIAN_FLIP_ON
+
+// Set to ON and OnStep will remember the last meridian flip pause at home setting (on/off), default=OFF
+#define REMEMBER_PAUSE_HOME_ON
+
+// ADJUST THE FOLLOWING TO MATCH YOUR MOUNT --------------------------------------------------------------------------------
+#define REMEMBER_MAX_RATE_ON         // set to ON and OnStep will remember rates set in the ASCOM driver or Android App, default=OFF 
+#define MaxRate                   96 // this is the minimum number of micro-seconds between micro-steps
+                                     // minimum* (fastest goto) is 16, default=96 higher is ok
+                                     // too low and OnStep communicates slowly and/or freezes as the motor timers use up all the MCU time
+                                     // * = minimum can be lower, when both AXIS1/AXIS2_MODE_GOTO are used by AXIS1/AXIS2_STEP_GOTO times
+
+#define DegreesForAcceleration   5.0 // approximate number of degrees for full acceleration or deceleration: higher values=longer acceleration/deceleration
+                                     // Default=5.0, too low (about <1) can cause gotos to never end if micro-step mode switching is enabled.
+#define DegreesForRapidStop      1.0 // approximate number of degrees required to stop when requested or if limit is exceeded during a slew: higher values=longer deceleration
+                                     // Default=1.0, too low (about <1) can cause gotos to never end if micro-step mode switching is enabled.
+
+#define BacklashTakeupRate        25 // backlash takeup rate (in multipules of the sidereal rate): too fast and your motors will stall,
+                                     // too slow and the mount will be sluggish while it moves through the backlash
+                                     // for the most part this doesn't need to be changed, but adjust when needed.  Default=25
+
+                                     // Axis1 is for RA/Az
+#define StepsPerDegreeAxis1  12800.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
+                                     // G11              :  400           * 32          * 1               *  360/360              = 12800
+                                     // Axis2 is for Dec/Alt
+#define StepsPerDegreeAxis2  12800.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
+                                     // G11              :  400           * 32          * 1               *  360/360              = 12800
+                                     
+                                     // PEC, number of steps for a complete worm rotation (in RA), (StepsPerDegreeAxis1*360)/gear_reduction2.  Ignored on Alt/Azm mounts.
+#define StepsPerWormRotationAxis1 12800L
+                                     // G11              : (12800*360)/360 = 12800
+
+#define PECBufferSize           824  // PEC, buffer size, max should be no more than 3384, your required buffer size >= StepsPerAxis1WormRotation/(StepsPerDegeeAxis1/240)
+                                     // for the most part this doesn't need to be changed, but adjust when needed.  824 seconds is the default.  Ignored on Alt/Azm mounts.
+
+#define MinutesPastMeridianE      60 // for goto's, how far past the meridian to allow before we do a flip (if on the East side of the pier) - one hour of RA is the default = 60.  Sometimes used for Fork mounts in Align mode.  Ignored on Alt/Azm mounts.
+#define MinutesPastMeridianW      60 // as above, if on the West side of the pier.  If left alone, the mount will stop tracking when it hits the this limit.  Sometimes used for Fork mounts in Align mode.  Ignored on Alt/Azm mounts.
+                                     // The above two lines can be removed and settings in EEPROM will be used instead, be sure to set the Meridian limits in control software if you do this!  
+                                     // If you don't remove these lines Meridian limits will return to these defaults on power up.
+#define UnderPoleLimit            12 // maximum allowed hour angle (+/-) under the celestial pole.  Default=12.  Ignored on Alt/Azm mounts.
+                                     // If left alone, the mount will stop tracking when it hits this limit.  Valid range is 10 to 12 hours.
+#define MinDec                   -91 // minimum allowed declination, default = -91 (off)  Ignored on Alt/Azm mounts.
+#define MaxDec                   +91 // maximum allowed declination, default =  91 (off)  Ignored on Alt/Azm mounts.
+                                     // For example, a value of +80 would stop gotos/tracking near the north celestial pole.
+                                     // For a Northern Hemisphere user, this would stop tracking when the mount is in the polar home position but
+                                     // that can be easily worked around by doing an alignment once and saving a park position (assuming a 
+                                     // fork/yolk mount with meridian flips turned off by setting the minutesPastMeridian values to cover the whole sky)
+#define MaxAzm                   180 // Alt/Az mounts only. +/- maximum allowed Azimuth, default =  180.  Allowed range is 180 to 360
+
+// AXIS1/2 STEPPER DRIVER CONTROL ------------------------------------------------------------------------------------------
+// Axis1: Pins  ?, ? = Step,Dir (RA/Azm)
+// Axis2: Pins  ?, ? = Step,Dir (Dec/Alt)
+
+// Reverse the direction of movement.  Adjust as needed or reverse your wiring so things move in the right direction
+#define REVERSE_AXIS1_OFF            // RA/Azm axis
+#define REVERSE_AXIS2_OFF            // Dec/Alt axis
+
+// Stepper driver Enable support, just wire Enable to Pins ? (Axis1) and ? (Axis2) and OnStep will pull these HIGH to disable the stepper drivers on startup and when Parked or Homed.  
+// An Align, Sync, or Un-Park will enable the drivers.  Adjust below if you need these pulled LOW to disable the drivers.
 #define AXIS1_DISABLED_HIGH
 #define AXIS2_DISABLED_HIGH
+
+// For equatorial mounts, _ON powers down the Declination axis when it's not being used to help lower power use.  During low rate guiding (<=1x) the axis stays enabled
+// for 10 minutes after any guide on either axis.  Otherwise, the Dec axis is disabled (powered off) 10 seconds after movement stops.
 #define AUTO_POWER_DOWN_AXIS2_OFF
-#define MODE_SWITCH_SLEEP_OFF
-// Include the pins file
+
+// Select stepper driver model and configure microstepping mode(s) if pins M0, M1, M2 are wired:
+#define AXIS1_DRIVER_MODEL_OFF      // Default _OFF, use A4988, DRV8825, LV8729, RAPS128, TMC2130, TMC2208 (for example: AXIS1_DRIVER_MODEL DRV8825)
+#define AXIS1_MICROSTEPS_OFF        // Axis1 (RA/Alt): Default _OFF, Microstep mode when the scope is doing sidereal tracking (for example: AXIS1_MICROSTEPS 32)
+#define AXIS1_MICROSTEPS_GOTO_OFF   // Axis1 (RA/Alt): Default _OFF, Optional microstep mode used during gotos
+
+#define AXIS2_DRIVER_MODEL_OFF      // Default _OFF, use A4988, DRV8825, LV8729, RAPS128, TMC2130, TMC2208
+#define AXIS2_MICROSTEPS_OFF        // Axis2 (RA/Alt): Default _OFF, Microstep mode when the scope is doing sidereal tracking
+#define AXIS2_MICROSTEPS_GOTO_OFF   // Axis2 (RA/Alt): Default _OFF, Optional microstep mode used during gotos
+
+// Stepper driver Fault detection on Pins ? (Aux1) and ? (Aux2,) choose only one feature to use on Aux1/2.
+// other settings are LOW, HIGH, SPI (Teensy3.2 applies internal pullup if _LOW and pulldown if _HIGH.)  The SPI interface (on M0/M1/M2/Aux) can be used to detect errors on the TMC2130.
+#define AXIS1_FAULT_OFF
+#define AXIS2_FAULT_OFF
+
+// ------------------------------------------------------------------------------------------------------------------------
+// THE FOLLOWING ARE INFREQUENTLY USED OPTIONS FOR THE MINIPCB SINCE USING ANY OF THESE WOULD REQUIRE SOLDERING TO THE PCB BACK AND ADDING OFF-PCB CIRCUITRY, MUCH EASIER TO USE A MAXPCB AND TEENSY3.5/3.6
+// FOCUSER ROTATOR OR ALT/AZ DE-ROTATION ----------------------------------------------------------------------------------
+// Pins ?,? = Step,Dir (choose either this option or the second focuser, not both)
+#define ROTATOR_OFF                  // enable or disable rotator feature (for any mount type,) default=OFF (de-rotator is available only for MOUNT_TYPE_ALTAZM.) [infrequently used option]
+#define MaxRateAxis3               8 // this is the minimum number of milli-seconds between micro-steps, default=8
+#define StepsPerDegreeAxis3     64.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
+                                     // Rotator          :  24            * 8           * 20              *  6/360                = 64
+                                     // For de-rotation of Alt/Az mounts a quick estimate of the required resolution (in StepsPerDegree)
+                                     // would be an estimate of the circumference of the useful imaging circle in (pixels * 2)/360
+#define REVERSE_AXIS3_OFF            // reverse the direction of Axis3 rotator movement
+#define DISABLE_AXIS3_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
+#define MinAxis3                -180 // minimum allowed Axis3 rotator, default = -180
+#define MaxAxis3                 180 // maximum allowed Axis3 rotator, default =  180
+
+// FOCUSER1 ---------------------------------------------------------------------------------------------------------------
+// Pins ?,? = Step,Dir
+#define FOCUSER1_OFF                 // enable or disable focuser feature, default=OFF
+#define MaxRateAxis4               8 // this is the minimum number of milli-seconds between micro-steps, default=8
+#define StepsPerMicrometerAxis4  0.5 // figure this out by testing or other means
+#define REVERSE_AXIS4_OFF            // reverse the direction of Axis4 focuser movement
+#define DISABLE_AXIS4_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
+#define MinAxis4               -25.0 // minimum allowed Axis4 position in millimeters, default = -25.0
+#define MaxAxis4                25.0 // maximum allowed Axis4 position in millimeters, default =  25.0
+
+// FOCUSER2 ---------------------------------------------------------------------------------------------------------------
+// Pins ?,? = Step,Dir (choose either this option or the rotator, not both)
+#define FOCUSER2_OFF                 // enable or disable focuser feature, default=OFF
+#define MaxRateAxis5               8 // this is the minimum number of milli-seconds between micro-steps, default=8
+#define StepsPerMicrometerAxis5  0.5 // figure this out by testing or other means
+#define REVERSE_AXIS5_OFF            // reverse the direction of Axis5 focuser movement
+#define DISABLE_AXIS5_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
+#define MinAxis5               -25.0 // minimum allowed Axis5 position in millimeters, default = -25.0
+#define MaxAxis5                25.0 // maximum allowed Axis5 position in millimeters, default =  25.0
+
+// THAT'S IT FOR USER CONFIGURATION!
+
+// -------------------------------------------------------------------------------------------------------------------------
 #include "Pins.STM32.h"
 #endif
-// === CONFIGURATION END
+

--- a/Constants.h
+++ b/Constants.h
@@ -1,8 +1,7 @@
 // -----------------------------------------------------------------------------------
 // Constants
 
-// simplified stepper driver mode setup
-#ifdef AXIS1_DRIVER_MODEL
+// Defines for simplified stepper driver mode setup
 
 // Stepper Driver Models
 #define A4988   1
@@ -25,6 +24,4 @@ unsigned int StepsDRV8825[LEN_DRV8825][2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,4}
 unsigned int StepsLV8729 [LEN_LV8729] [2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,4}, {32,5}, {64,6}, {128,7} };
 unsigned int StepsTMC2208[LEN_TMC2208][2] = {        {2,0}, {4,1}, {8,2}, {16,3} };
 unsigned int StepsTMC2130[LEN_TMC2130][2] = { {1,8}, {2,7}, {4,6}, {8,5}, {16,4}, {32,3}, {64,2}, {128,1}, {256,0} };
-
-#endif
 

--- a/Constants.h
+++ b/Constants.h
@@ -7,35 +7,31 @@
 #define TMC_NINTPOL     16
 #define SYNC_ANYWHERE_ON
 
-// simplified stepper driver mode setup
-#ifdef AXIS1_DRIVER_MODEL
+// Stepper Driver Models
+#define A4988   1
+#define DRV8825 2
+#define LV8729  3
+#define RAPS128 3
+#define TMC2208 5
 
-  // Stepper Driver Models
-  #define A4988   1
-  #define DRV8825 2
-  #define LV8729  3
-  #define RAPS128 3
-  #define TMC2208 5
-
-  #define TMC2130 100
-  #define TMC2130_QUIET 101  // these variations don't appear at run-time and are changed to "TMC2130"
-  #define TMC2130_VQUIET 102
-  #define TMC2130_QUIET_LOWPWR 103
-  #define TMC2130_VQUIET_LOWPWR 104
+#define TMC2130 100
+#define TMC2130_QUIET 101  // these variations don't appear at run-time and are changed to "TMC2130"
+#define TMC2130_VQUIET 102
+#define TMC2130_QUIET_LOWPWR 103
+#define TMC2130_VQUIET_LOWPWR 104
   
-  // Length of each stepper's table
-  #define LEN_A4988   5
-  #define LEN_DRV8825 6
-  #define LEN_LV8729  8
-  #define LEN_TMC2208 4
-  #define LEN_TMC2130 9
+// Length of each stepper's table
+#define LEN_A4988   5
+#define LEN_DRV8825 6
+#define LEN_LV8729  8
+#define LEN_TMC2208 4
+#define LEN_TMC2130 9
     
-  // The various microsteps for different driver models, with the bit modes for each
-  unsigned int StepsA4988  [LEN_A4988]  [2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,7} };
-  unsigned int StepsDRV8825[LEN_DRV8825][2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,4}, {32,5} };
-  unsigned int StepsLV8729 [LEN_LV8729] [2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,4}, {32,5}, {64,6}, {128,7} };
-  unsigned int StepsTMC2208[LEN_TMC2208][2] = {        {2,0}, {4,1}, {8,2}, {16,3} };
-  unsigned int StepsTMC2130[LEN_TMC2130][2] = { {1,8}, {2,7}, {4,6}, {8,5}, {16,4}, {32,3}, {64,2}, {128,1}, {256,0} };
+// The various microsteps for different driver models, with the bit modes for each
+unsigned int StepsA4988  [LEN_A4988]  [2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,7} };
+unsigned int StepsDRV8825[LEN_DRV8825][2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,4}, {32,5} };
+unsigned int StepsLV8729 [LEN_LV8729] [2] = { {1,0}, {2,1}, {4,2}, {8,3}, {16,4}, {32,5}, {64,6}, {128,7} };
+unsigned int StepsTMC2208[LEN_TMC2208][2] = {        {2,0}, {4,1}, {8,2}, {16,3} };
+unsigned int StepsTMC2130[LEN_TMC2130][2] = { {1,8}, {2,7}, {4,6}, {8,5}, {16,4}, {32,3}, {64,2}, {128,1}, {256,0} };
 
-#endif
 

--- a/Validate.h
+++ b/Validate.h
@@ -1,8 +1,6 @@
 // -----------------------------------------------------------------------------------
 // Validate current configuration
 
-#include "Constants.h"
-
 #if !defined(Classic_ON) && !defined(MiniPCB_ON) && !defined(MaxPCB_ON) && !defined(TM4C_ON) && !defined(Ramps14_ON) && !defined(Mega2560Alt_ON) && !defined(STM32_ON)
   #error "Choose ONE Config.xxx.h file and enable it for use by turning it _ON."
 #endif

--- a/Validate.h
+++ b/Validate.h
@@ -88,9 +88,7 @@
   #endif
 #endif
 
-/*
 #ifdef AXIS1_DRIVER_MODEL
-*/
   // attempting to use the simplified stepper driver setup
 
   // special SPI modes for TMC2130
@@ -299,4 +297,4 @@
   #endif
 
 #endif
-
+#endif

--- a/Validate.h
+++ b/Validate.h
@@ -14,9 +14,9 @@
 #endif
 
 #if defined(MaxPCB) || defined(MiniPCB)
-#if defined(RETICULE_LED_PINS) && (defined(STATUS_LED_PINS_ON) || defined(STATUS_LED_PINS))
-  #error "You can't have the Illuminated Reticule and Status2 LEDs both enabled in this configuration."
-#endif
+  #if defined(RETICULE_LED_PINS) && (defined(STATUS_LED_PINS_ON) || defined(STATUS_LED_PINS))
+    #error "You can't have the Illuminated Reticule and Status2 LEDs both enabled in this configuration."
+  #endif
 #endif
 
 // -----------------------------------------------------------------------------------
@@ -55,32 +55,42 @@
 
 // misc. configuration #defines to correct for backwards compatability etc.
 #ifdef SEPERATE_PULSE_GUIDE_RATE_ON
-#define SEPARATE_PULSE_GUIDE_RATE_ON
+  #define SEPARATE_PULSE_GUIDE_RATE_ON
 #endif
 #ifndef GUIDE_TIME_LIMIT
-#define GUIDE_TIME_LIMIT 0
+  #define GUIDE_TIME_LIMIT 0
 #endif
 #ifndef MaxRot
-#define MaxRot MaxAxis3
+  #define MaxRot MaxAxis3
 #endif
 #ifndef MinRot
-#define MinRot MinAxis3
+  #define MinRot MinAxis3
 #endif
 #ifndef AXIS1_STEP_GOTO
-#define AXIS1_STEP_GOTO 1
+  #define AXIS1_STEP_GOTO 1
 #endif
 #ifndef AXIS2_STEP_GOTO
-#define AXIS2_STEP_GOTO 1
+  #define AXIS2_STEP_GOTO 1
 #endif
 
 // -----------------------------------------------------------------------------------
 // stepper driver mode setup
 
-#if (defined(AXIS1_DRIVER_MODEL) && (!defined(AXIS2_DRIVER_MODEL)) || (defined(AXIS2_DRIVER_MODEL) && (!defined(AXIS1_DRIVER_MODEL))
-  #error "AXISn_DRIVER_MODEL; If using the simplified driver mode setup you must use it for both AXIS1 and AXIS2."
+#ifdef AXIS1_DRIVER_MODEL
+  #ifndef AXIS2_DRIVER_MODEL
+    #error "AXISn_DRIVER_MODEL; If using the simplified driver mode setup you must use it for both AXIS1 and AXIS2."
+  #endif
 #endif
 
-#if defined(AXIS1_DRIVER_MODEL)
+#ifdef AXIS2_DRIVER_MODEL
+  #ifndef AXIS1_DRIVER_MODEL
+    #error "AXISn_DRIVER_MODEL; If using the simplified driver mode setup you must use it for both AXIS1 and AXIS2."
+  #endif
+#endif
+
+/*
+#ifdef AXIS1_DRIVER_MODEL
+*/
   // attempting to use the simplified stepper driver setup
 
   // special SPI modes for TMC2130
@@ -289,5 +299,4 @@
   #endif
 
 #endif
-
 


### PR DESCRIPTION
The Constants.h file should be included only once. 

There should be no conditional defines in it either, since no configs have been included yet.

Even though the defines are mostly for AXISn_MICROSTEPS, then do nothing if that new configuration is used. They are just defines and declarations.

Tested to compile on all platforms (except Tiva C).