### PR TITLE
Make E2END definition in the calling HAL_x.h mandatory

### DIFF
--- a/src/HAL/HAL_Due/HAL_Due.h
+++ b/src/HAL/HAL_Due/HAL_Due.h
@@ -3,6 +3,10 @@
 // We define a more generic symbol, in case more Teensy boards based on different lines are supported
 // __SAM3X8E__
 
+// The full EEPROM size causes problems, so we use a smaller one
+//#define E2END 32767
+#define E2END 8191
+
 // OnStep needs EEPROM, the DUE doesn't have it and the flash eeprom libraries are limited so use an I2C 
 #include "../drivers/HAL_24LC256.h"
 

--- a/src/HAL/drivers/HAL_24LC256.h
+++ b/src/HAL/drivers/HAL_24LC256.h
@@ -1,9 +1,5 @@
 // Support for 24LC256 I2C EEPROM
 
-// The full EEPROM size causes problems
-//#define E2END 32767
-#define E2END 8191
-
 #include <Wire.h>
 #define PWire Wire
 


### PR DESCRIPTION
This is to generalize the 24LC library in src/HAL/drivers. 

By making E2END mandatory in the calling HAL_x.h, we can reuse the 24LC library in other platforms transparently.