### PR TITLE
RAMPS 1.4 improvement

### DIFF
--- a/src/addons/WiFi-Bluetooth/WiFi-Bluetooth.ino
+++ b/src/addons/WiFi-Bluetooth/WiFi-Bluetooth.ino
@@ -169,7 +169,7 @@ void handleNotFound(){
 }
 
 void setup(void){
-
+delay(5000); //to be sure that the main board (ramps 1.4) is fully started before starting ESP8266
 #ifdef LED_PIN
   pinMode(LED_PIN,OUTPUT);
 #endif


### PR DESCRIPTION
Following some bugs at boot-up, on the serial link, it's necessary to be sure that the main board (RAMPS 1.4) is fully started before starting ESP8266.
Maybe, it is possible to decrease the delay. 