### PR TITLE
STM32F103C8T6 Black Pill support, with I2C EEPROM via DS3231 module

### DIFF
--- a/Config.STM32.h
+++ b/Config.STM32.h
@@ -1,212 +1,87 @@
-// -----------------------------------------------------------------------------------
-// Configuration for OnStep on the STM32F103V and STM32F103Z (the faster STM32F407 has no EEPROM support at present)
-
-/*
- * For more information on setting OnStep up see http://www.stellarjourney.com/index.php?r=site/equipment_onstep and 
- * join the OnStep Groups.io at https://groups.io/g/onstep
- * 
- * See the Pins.STM32.h file for detailed information on this pin map to be sure it matches your wiring *** USE AT YOUR OWN RISK ***
- *
-*/
-
-#define STM32_OFF   //  <- Turn _ON to use this configuration
-
+#define STM32_OFF
 #ifdef STM32_ON
-// -------------------------------------------------------------------------------------------------------------------------
-// ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
-
-// Enables internal goto assist mount modeling (for Eq mounts), default=_OFF (Experimental)
-// Note that Goto Assist in Sky Planetarium works even if this is off
-#define ALIGN_GOTOASSIST_ON
-
-// Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
-
-// ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01
-// Pin ? (Aux1) for GPIO0 and Pin ? (Aux2) for Rst control.  Choose only one feature on Aux1/2.
-#define ESP8266_CONTROL_OFF
-
-// Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
-// _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)
 #define MOUNT_TYPE_GEM
+#define StepsPerDegreeAxis1 9600.0
+#define StepsPerWormRotationAxis1 24000.0
+#define AXIS1_DRIVER_MODEL LV8729
+#define AXIS1_MICROSTEPS 32
+#define AXIS1_MICROSTEPS_GOTO 1
 
-// Strict parking, default=_OFF.  Set to _ON and unparking is only allowed if successfully parked.  Otherwise unparking is allowed if at home and not parked (the Home/Reset command ":hF#" sets this state.) 
-#define STRICT_PARKING_OFF
+#define StepsPerDegreeAxis2 9600.0
+#define StepsPerWormRotationAxis2 24000.0
+#define AXIS2_DRIVER_MODEL LV8729
+#define AXIS2_MICROSTEPS 32
+#define AXIS2_MICROSTEPS_GOTO 1
 
-// ST4 interface on pins ?, ?, ?, ?.  Pin ? is RA- (West), Pin ? is Dec- (South), Pin ? is Dec+ (North), Pin ? is RA+ (East.)
-// ST4_ON enables the interface, ST4_PULLUP enables the interface and any internal pullup resistors.
-// It is up to you to create an interface that meets the electrical specifications of any connected device, use at your own risk.  default=_OFF
-#define ST4_OFF
-// If SEPARATE_PULSE_GUIDE_RATE_ON is used the ST4 port is limited to guide rates <= 1X except when ST4_HAND_CONTROL_ON is used.
-// Additionally, ST4_HAND_CONTROL_ON enables special features: Press and hold [E]+[W] buttons for > 2 seconds...  In this mode [E] decreases and [W] increases guide rates (or if tracking isn't on yet adjusts illuminated recticule brightness.)
-// [S] for Sync (or Accept if in align mode.) [N] for Tracking on/off. -OR- Press and hold [N]+[S] buttons for > 2 seconds...  In this mode [E] selects prior and [W] next user catalog item.
-// [N] to do a Goto to the catalog item.  [S] for Sound on/off.  The keypad returns to normal operation after 4 seconds of inactivity.  ST4_HAND_CONTROL_ON also adds a 100ms de-bounce to all button presses.
-// Finally, during a goto pressing any button aborts the slew.  If meridian flip paused at home, pressing any button continues.  default=_ON
-#define ST4_HAND_CONTROL_ON
+#define MaxRate 20
+#define PECBufferSize 600
 
-// Separate pulse-guide rate so centering and guiding don't disturb each other, default=_ON
-#define SEPARATE_PULSE_GUIDE_RATE_ON
-
-// Guide time limit (in seconds,) default=0 (no limit.)  A safety feature, some guides are started with one command and stopped with another.  
-// If the stop command is never received the guide will continue forever unless this is enabled.
-#define GUIDE_TIME_LIMIT 0
-
-// PPS use _ON or _PULLUP to enable the input and use the built-in pullup resistor.  Sense rising edge on Pin ? for optional precision clock source (GPS, for example), default=_OFF [infrequently used option]
-#define PPS_SENSE_OFF
-
-// PEC sense on Pin ? use _ON or _PULLUP to enable the input/use the built-in pullup resistor (digital input) or provide a comparison value (see below) for analog operation, default=_OFF
-// Analog values range from 0 to 1023 which indicate voltages from 0-3.3VDC on the analog pin, for example "PEC_SENSE 600" would detect an index when the voltage exceeds 1.93V
-// With either index detection method, once triggered 60s must expire before another detection can happen.  This gives time for the index magnet to pass by the detector before another cycle begins.
-// Ignored on Alt/Azm mounts.
-#define PEC_SENSE_OFF
-// PEC sense, rising edge (default with PEC_SENSE_STATE HIGH, use LOW for falling edge, ex. PEC_SENSE_ON) ; for optional PEC index
-#define PEC_SENSE_STATE HIGH
-
-// Switch close (to ground) on Pin ? for optional limit sense (stops gotos and/or tracking), default=_OFF
-#define LIMIT_SENSE_OFF
-
-// Light status LED by sink to ground (Pin ?), default=_ON.
-// _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash
-#define STATUS_LED_PINS_OFF
-// Light 2nd status LED by sink to ground (Pin ?), default=_OFF.
-// _ON sets this to blink at 1 sec intervals when PPS is synced.  Turns off if tracking is stopped.  Turns on during gotos.
-#define STATUS_LED2_PINS_OFF
-// Light reticule LED by sink to ground (Pin ?), default=_OFF.  (don't use with STATUS_LED2_PINS_ON)
-// RETICULE_LED_PINS n, where n=0 to 255 activates this feature and sets default brightness
-#define RETICULE_LED_PINS_OFF
-
-// Sound/buzzer on Pin ?, default=_OFF.
-// Specify frequency for a piezo speaker (for example "BUZZER 2000") or use BUZZER_ON for a piezo buzzer.
-#define BUZZER_OFF
-// Sound state at startup, default=_ON.
-#define DEFAULT_SOUND_ON
-
-// Optionally adjust tracking rate to compensate for atmospheric refraction, default=_OFF
-// can be turned on/off with the :Tr# and :Tn# commands regardless of this setting
+#define FileVersionConfig 1
+#define AUTOSTART_TRACKING_ON
+// The following are useful, so defaulted to ON
 #define TRACK_REFRACTION_RATE_DEFAULT_ON
+#define REMEMBER_MAX_RATE_ON
 
-// Set to _ON and OnStep will remember the last auto meridian flip setting (on/off), default=_OFF
-#define REMEMBER_AUTO_MERIDIAN_FLIP_ON
-
-// Set to _ON and OnStep will remember the last meridian flip pause at home setting (on/off), default=_OFF
-#define REMEMBER_PAUSE_HOME_ON
-
-// ADJUST THE FOLLOWING TO MATCH YOUR MOUNT --------------------------------------------------------------------------------
-#define REMEMBER_MAX_RATE_OFF        // set to _ON and OnStep will remember rates set in the ASCOM driver, Android App, etc. default=_OFF 
-#define MaxRate                   96 // microseconds per microstep default setting for gotos, can be adjusted for two times lower or higher at run-time
-                                     // minimum* (fastest goto) is around 16, default=96 higher is ok
-                                     // * = minimum can be lower, when both AXIS1/AXIS2_MICROSTEPS are used the compiler will warn you if it's too low
-
-#define DegreesForAcceleration   5.0 // approximate number of degrees for full acceleration or deceleration: higher values=longer acceleration/deceleration
-                                     // Default=5.0, too low (about <1) can cause gotos to never end if micro-step mode switching is enabled.
-#define DegreesForRapidStop      1.0 // approximate number of degrees required to stop when requested or if limit is exceeded during a slew: higher values=longer deceleration
-                                     // Default=1.0, too low (about <1) can cause gotos to never end if micro-step mode switching is enabled.
-
-#define BacklashTakeupRate        25 // backlash takeup rate (in multipules of the sidereal rate): too fast and your motors will stall,
-                                     // too slow and the mount will be sluggish while it moves through the backlash
-                                     // for the most part this doesn't need to be changed, but adjust when needed.  Default=25
-
-                                     // Axis1 is for RA/Az
-#define StepsPerDegreeAxis1  12800.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
-                                     // G11              :  400           * 32          * 1               *  360/360              = 12800
-                                     // Axis2 is for Dec/Alt
-#define StepsPerDegreeAxis2  12800.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
-                                     // G11              :  400           * 32          * 1               *  360/360              = 12800
-                                     
-                                     // PEC, number of steps for a complete worm rotation (in RA), (StepsPerDegreeAxis1*360)/gear_reduction2.  Ignored on Alt/Azm mounts.
-#define StepsPerWormRotationAxis1 12800L
-                                     // G11              : (12800*360)/360 = 12800
-
-#define PECBufferSize           824  // PEC, buffer size, max should be no more than 3384, your required buffer size >= StepsPerAxis1WormRotation/(StepsPerDegeeAxis1/240)
-                                     // for the most part this doesn't need to be changed, but adjust when needed.  824 seconds is the default.  Ignored on Alt/Azm mounts.
-
-#define MinutesPastMeridianE      30 // for goto's, how far past the meridian to allow before we do a flip (if on the East side of the pier) - a half hour of RA is the default = 30.  Sometimes used for Fork mounts in Align mode.  Ignored on Alt/Azm mounts.
-#define MinutesPastMeridianW      30 // as above, if on the West side of the pier.  If left alone, the mount will stop tracking when it hits the this limit.  Sometimes used for Fork mounts in Align mode.  Ignored on Alt/Azm mounts.
-                                     // The above two lines can be removed and settings in EEPROM will be used instead, be sure to set the Meridian limits in control software if you do this!  
-                                     // If you don't remove these lines Meridian limits will return to these defaults on power up.
-#define UnderPoleLimit            12 // maximum allowed hour angle (+/-) under the celestial pole.  Default=12.  Ignored on Alt/Azm mounts.
-                                     // If left alone, the mount will stop tracking when it hits this limit.  Valid range is 10 to 12 hours.
-#define MinDec                   -91 // minimum allowed declination, default = -91 (off)  Ignored on Alt/Azm mounts.
-#define MaxDec                   +91 // maximum allowed declination, default =  91 (off)  Ignored on Alt/Azm mounts.
-                                     // For example, a value of +80 would stop gotos/tracking near the north celestial pole.
-                                     // For a Northern Hemisphere user, this would stop tracking when the mount is in the polar home position but
-                                     // that can be easily worked around by doing an alignment once and saving a park position (assuming a 
-                                     // fork/yolk mount with meridian flips turned off by setting the minutesPastMeridian values to cover the whole sky)
-#define MaxAzm                   180 // Alt/Az mounts only. +/- maximum allowed Azimuth, default =  180.  Allowed range is 180 to 360
-
-// AXIS1/2 STEPPER DRIVER CONTROL ------------------------------------------------------------------------------------------
-// Axis1: Pins  ?, ? = Step,Dir (RA/Azm)
-// Axis2: Pins  ?, ? = Step,Dir (Dec/Alt)
-
-// Reverse the direction of movement.  Adjust as needed or reverse your wiring so things move in the right direction
-#define AXIS1_REVERSE_OFF            // RA/Azm axis
-#define AXIS2_REVERSE_OFF            // Dec/Alt axis
-
-// Stepper driver Enable support, just wire Enable to Pins ? (Axis1) and ? (Axis2) and OnStep will pull these HIGH to disable the stepper drivers on startup and when Parked or Homed.  
-// An Align, Sync, or Un-Park will enable the drivers.  Adjust below if you need these pulled LOW to disable the drivers.
-#define AXIS1_DISABLE HIGH
-#define AXIS2_DISABLE HIGH
-
-// For equatorial mounts, _ON powers down the Declination axis when it's not being used to help lower power use.  During low rate guiding (<=1x) the axis stays enabled
-// for 10 minutes after any guide on either axis.  Otherwise, the Dec axis is disabled (powered off) 10 seconds after movement stops.
-#define AXIS2_AUTO_POWER_DOWN_OFF
-
-// Basic stepper driver mode setup . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-// If used, this requires connections M0, M1, and M2 on Pins ?,?,? for Axis1 (RA/Azm) and Pins ?,?,? for Axis2 (Dec/Alt.)
-// Stepper driver models are as follows: (for example AXIS1_DRIVER_MODEL DRV8825,) A4988, LV8729, RAPS128, TMC2208, TMC2130 (spreadCycle,) 
-// TMC2130_QUIET (stealthChop tracking,) TMC2130_VQUIET (full stealthChop mode,) add _LOWPWR for 50% power during tracking (for example: TMC2130_QUIET_LOWPWR)
-#define AXIS1_DRIVER_MODEL_OFF      // Axis1 (RA/Azm):  Default _OFF, Stepper driver model (see above)
-#define AXIS1_MICROSTEPS_OFF        // Axis1 (RA/Azm):  Default _OFF, Microstep mode when the scope is doing sidereal tracking (for example: AXIS1_MICROSTEPS 32)
-#define AXIS1_MICROSTEPS_GOTO_OFF   // Axis1 (RA/Azm):  Default _OFF, Optional microstep mode used during gotos (for example: AXIS1_MICROSTEPS_GOTO 2)
-#define AXIS2_DRIVER_MODEL_OFF      // Axis2 (Dec/Alt): Default _OFF, Stepper driver model (see above)
-#define AXIS2_MICROSTEPS_OFF        // Axis2 (Dec/Alt): Default _OFF, Microstep mode when the scope is doing sidereal tracking
-#define AXIS2_MICROSTEPS_GOTO_OFF   // Axis2 (Dec/Alt): Default _OFF, Optional microstep mode used during gotos
-// Note: you can replace this section with the contents of "AdvancedStepperSetup.txt" . . . . . . . . . . . . . . . . . . . 
-
-// Stepper driver Fault detection on Pins ? (Aux1) and ? (Aux2,) choose only one feature to use on Aux1/2.  The SPI interface (on M0/M1/M2/Aux) can be used to detect errors on the TMC2130.
-// other settings are LOW, HIGH, TMC2130 (if available applies internal pullup if LOW and pulldown if HIGH.)
+// The following are less common options. Edit them by manually.
 #define AXIS1_FAULT_OFF
 #define AXIS2_FAULT_OFF
-
-// ------------------------------------------------------------------------------------------------------------------------
-// THE FOLLOWING ARE INFREQUENTLY USED OPTIONS FOR THE MINIPCB SINCE USING ANY OF THESE WOULD REQUIRE SOLDERING TO THE PCB BACK AND ADDING OFF-PCB CIRCUITRY, MUCH EASIER TO USE A MAXPCB AND TEENSY3.5/3.6
-// FOCUSER ROTATOR OR ALT/AZ DE-ROTATION ----------------------------------------------------------------------------------
-// Pins ?,? = Step,Dir (choose either this option or the second focuser, not both)
-#define ROTATOR_OFF                  // enable or disable rotator feature (for any mount type,) default=_OFF (de-rotator is available only for MOUNT_TYPE_ALTAZM.) [infrequently used option]
-#define MaxRateAxis3               8 // this is the minimum number of milli-seconds between micro-steps, default=8
-#define StepsPerDegreeAxis3     64.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
-                                     // Rotator          :  24            * 8           * 20              *  6/360                = 64
-                                     // For de-rotation of Alt/Az mounts a quick estimate of the required resolution (in StepsPerDegree)
-                                     // would be an estimate of the circumference of the useful imaging circle in (pixels * 2)/360
-#define AXIS3_REVERSE_OFF            // reverse the direction of Axis3 rotator movement
-#define AXIS3_DISABLE_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
-#define MinAxis3                -180 // minimum allowed Axis3 rotator, default = -180
-#define MaxAxis3                 180 // maximum allowed Axis3 rotator, default =  180
-
-// FOCUSER1 ---------------------------------------------------------------------------------------------------------------
-// Pins ?,? = Step,Dir
-#define FOCUSER1_OFF                 // enable or disable focuser feature, default=_OFF
-#define MaxRateAxis4               8 // this is the minimum number of milli-seconds between micro-steps, default=8
-#define StepsPerMicrometerAxis4  0.5 // figure this out by testing or other means
-#define AXIS4_REVERSE_OFF            // reverse the direction of Axis4 focuser movement
-#define AXIS4_DISABLE_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
-#define MinAxis4               -25.0 // minimum allowed Axis4 position in millimeters, default = -25.0
-#define MaxAxis4                25.0 // maximum allowed Axis4 position in millimeters, default =  25.0
-
-// FOCUSER2 ---------------------------------------------------------------------------------------------------------------
-// Pins ?,? = Step,Dir (choose either this option or the rotator, not both)
-#define FOCUSER2_OFF                 // enable or disable focuser feature, default=_OFF
-#define MaxRateAxis5               8 // this is the minimum number of milli-seconds between micro-steps, default=8
-#define StepsPerMicrometerAxis5  0.5 // figure this out by testing or other means
-#define AXIS5_REVERSE_OFF            // reverse the direction of Axis5 focuser movement
-#define AXIS5_DISABLE_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
-#define MinAxis5               -25.0 // minimum allowed Axis5 position in millimeters, default = -25.0
-#define MaxAxis5                25.0 // maximum allowed Axis5 position in millimeters, default =  25.0
-
-// THAT'S IT FOR USER CONFIGURATION!
-
-// -------------------------------------------------------------------------------------------------------------------------
-#define FileVersionConfig 2
+#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL4_BAUD_DEFAULT 9600
+#define ESP8266_CONTROL_OFF
+#define STRICT_PARKING_OFF
+#define ST4_OFF
+#define ST4_HAND_CONTROL_ON
+#define SEPARATE_PULSE_GUIDE_RATE_ON
+#define GUIDE_TIME_LIMIT 0
+#define RTC_OFF
+#define PPS_SENSE_OFF
+#define PEC_SENSE_OFF
+#define PEC_SENSE_STATE HIGH
+#define LIMIT_SENSE_OFF
+#define STATUS_LED_PINS_ON
+#define STATUS_LED2_PINS_OFF
+#define RETICULE_LED_PINS_OFF
+#define BUZZER_OFF
+#define DEFAULT_SOUND_ON
+#define REMEMBER_AUTO_MERIDIAN_FLIP_ON
+#define REMEMBER_PAUSE_HOME_ON
+#define REVERSE_AXIS1_OFF
+#define REVERSE_AXIS2_OFF
+#define DegreesForAcceleration 5.0
+#define DegreesForRapidStop 1.0
+#define BacklashTakeupRate 25
+#define MinutesPastMeridianE 60
+#define MinutesPastMeridianW 60
+#define UnderPoleLimit 12
+#define MinDec -91
+#define MaxDec +91
+#define MaxAzm 180
+#define AXIS1_DISABLED_HIGH
+#define AXIS2_DISABLED_HIGH
+#define AUTO_POWER_DOWN_AXIS2_OFF
+#define AXIS1_FAULT_OFF
+#define AXIS2_FAULT_OFF
+#define ROTATOR_OFF
+#define MaxRateAxis3 8
+#define StepsPerDegreeAxis3 64.0
+#define REVERSE_AXIS3_OFF
+#define DISABLE_AXIS3_OFF
+#define MinAxis3 -180
+#define MaxAxis3 180
+#define FOCUSER1_OFF
+#define MaxRateAxis4 8
+#define StepsPerMicrometerAxis4 0.5
+#define REVERSE_AXIS4_OFF
+#define DISABLE_AXIS4_OFF
+#define MinAxis4 -25.0
+#define MaxAxis4 25.0
+#define FOCUSER2_OFF
+#define MaxRateAxis5 8
+#define StepsPerMicrometerAxis5 0.5
+#define REVERSE_AXIS5_OFF
+#define DISABLE_AXIS5_OFF
+#define MinAxis5 -25.0
+#define MaxAxis5 25.0
+// Include the pins file
 #include "Pins.STM32.h"
 #endif
-

--- a/Pins.STM32.h
+++ b/Pins.STM32.h
@@ -1,14 +1,19 @@
 // -------------------------------------------------------------------------------------------------
-// Pin map for OnStep on STM32F103
-// Boards based on the following chips have enough flash and RAM for OnStep, and should work with 
-// the pins below:
+// Pin map for OnStep on STM32
+// 
+// This pin map is for an STM32F103C8T6 "Black Pill" stick.
+// It runs at 72MHz has 128K flash and 20K RAM, and is 3.3V only
+//
+// Cost on eBay and AliExpress is less than US $2.50
+// More info, schematic at:
+//   http://wiki.stm32duino.com/index.php?title=Black_Pill
+//
+// Other boards based on the following chips also have enough flash
+// and RAM for OnStep, and should work, with pin modifications.
 //
 // STM32103VC: 72MHz, 256K flash, 48K RAM
 // STM32103VE: 72MHz, 512K flash, 64K RAM
 // STM32103ZE: 72MHz, 512K flash, 64K RAM
-
-// The following boards should also work, but you have to modify the pins below:
-//
 // STM32103RC: 72MHz, 256K flash, 48K RAM
 // STM32103RE: 72MHz, 512K flash, 64K RAM
 
@@ -16,58 +21,63 @@
 
 // The pins here are not tested yet, and need to change 
 
-#define Axis1_EN      PD10   // Enable
-#define Axis1DirPin   PD12   // Motor Direction
-#define Axis1StepPin  PD14   // Step
-#define Axis1_M2      PD11   // Microstep Mode 2 or SPI CS
-#define Axis1_M1      PD13   // Microstep Mode 1 or SPI SCK
-#define Axis1_M0      PD15   // Microstep Mode 0 or SPI MOSI
-#define Axis1_FAULT   PD9    // Fault
-#define Axis1_Aux     Axis1_Aux    // Aux - ESP8266 GPIO0 or SPI MISO
+#define Axis1_EN        PB11   // Enable
+#define Axis1_M0        PB10   // Microstep Mode 0
+#define Axis1_M1        PB1    // Microstep Mode 1
+#define Axis1_M2        PB0    // Microstep Mode 2
+#define Axis1StepPin    PA7    // Step
+#define Axis1DirPin     PA6    // Motor Direction
+//#define Axis1_FAULT   Undefined    // Fault
+//#define Axis1_Aux     Axis1_Aux    // Aux - ESP8266 GPIO0 or SPI MISO
 
-#define Axis2_EN      PE10   // Enable
-#define Axis2DirPin   PE12   // Motor Direction
-#define Axis2StepPin  PE14   // Step
-#define Axis2_M2      PE11   // Microstep Mode 2 or SPI CS
-#define Axis2_M1      PE13   // Microstep Mode 1 or SPI SCK
-#define Axis2_M0      PE15   // Microstep Mode 0 or SPI MOSI
-#define Axis2_FAULT   PE9    // Fault
-#define Axis2_Aux     Axis2_FAULT    // Aux - ESP8266 RST or SPI MISO
+#define Axis2_EN        PA5    // Enable
+#define Axis2_M0        PA4    // Microstep Mode 0
+#define Axis2_M1        PA3    // Microstep Mode 1
+#define Axis2_M2        PA2    // Microstep Mode 2
+#define Axis2StepPin    PA1    // Step
+#define Axis2DirPin     PA0    // Motor Direction
+//#define Axis2_FAULT   Undefined    // Fault
+//#define Axis2_Aux     Axis2_FAULT  // Aux - ESP8266 RST or SPI MISO
 
-// The PEC index sense is a logic level input, resets the PEC index on rising edge then waits for 60 seconds before allowing another reset
-#define PecPin        PA10
-#define AnalogPecPin  PA11    // PEC Sense, analog or digital
-
-// The status LED is a two wire jumper with a 10k resistor in series to limit the current to the LED
-#define LEDnegPin     PA12    // Drain
-#define LEDneg2Pin    PA13    // Drain
-#define ReticulePin   PA13    // Drain
+// This is the built in LED for the Black Pill board. There is a pin
+// available from it too, in case you want to power another LED with a wire
+#define LEDnegPin       PB12         // Drain
+//#define LEDneg2Pin    Undefined    // Drain
+//#define ReticulePin   Undefined    // Drain
 
 // For a piezo buzzer
-#define TonePin       PA14    // Tone
-
-// The PPS pin is a 3.3V logic input, OnStep measures time between rising edges and adjusts the internal sidereal clock frequency
-#define PpsPin        PA15    // Pin 28 (PPS time source, GPS for example)
-
-#define LimitPin       PB2    // The limit switch sense is a logic level input which uses the internal pull up, shorted to ground it stops gotos/tracking
-
-// For rotator stepper driver
-#define Axis3DirPin   PC1    // Dir
-#define Axis3StepPin  PC2    // Step
-
-// Pins to focuser1 stepper driver
-#define Axis4DirPin   PC3    // Dir
-#define Axis4StepPin  PC4    // Step
-
-// For focuser2 stepper driver
-#define Axis5DirPin   PC1    // Dir
-#define Axis5StepPin  PC2    // Step
+#define TonePin         PA8  // Tone
 
 // ST4 interface
-#define ST4RAw        PD10    // ST4 RA- West
-#define ST4DEs        PD11    // ST4 DE- South
-#define ST4DEn        PD12    // ST4 DE+ North
-#define ST4RAe        PD13    // ST4 RA+ East
+#define ST4DEn          PB13  // ST4 DE+ North
+#define ST4DEs          PB14  // ST4 DE- South
+#define ST4RAw          PB15  // ST4 RA- West
+#define ST4RAe          PA8   // ST4 RA+ East
+
+// Pins to focuser1 stepper driver
+#define Axis4DirPin     A15    // Dir
+#define Axis4StepPin    PB3    // Step
+
+// For rotator stepper driver
+#define Axis3DirPin     PB4    // Dir
+#define Axis3StepPin    PB5    // Step
+
+// For focuser2 stepper driver
+//#define Axis5DirPin   Undefined    // Dir
+//#define Axis5StepPin  Undefined    // Step
+
+// The limit switch sense is a logic level input which uses the internal pull up,
+// shorted to ground it stops gotos/tracking
+//#define LimitPin      Undefined   
+
+// The PEC index sense is a logic level input, resets the PEC index on rising
+// edge then waits for 60 seconds before allowing another reset
+//#define PecPin       Undefined
+//#define AnalogPecPin Undefined    // PEC Sense, analog or digital
+
+// The PPS pin is a 3.3V logic input, OnStep measures time between rising edges and
+// adjusts the internal sidereal clock frequency
+//#define PpsPin       Undefined    // Pulse Per Second time source, e.g. GPS
 
 #else
 #error "Wrong processor for this configuration!"

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -3,7 +3,17 @@
 // We define a more generic symbol, in case more STM32 boards based on different lines are supported
 #define __ARM_STM32__
 
-#include <EEPROM.h>
+// The STM32 platform has no built in EEPROM. Although there is EEPROM emulation in flash, it does
+// work. Therefore a real EEPROM is needed. 
+// The best way is to use the low cost DS3231 RTC module, which has a 4K I2C EEPROM built in.
+// The EEPROM's address is different from the default, so we define it before including HAL_24LC.h
+#define I2C_EEPROM_ADDRESS 0x57
+
+// End of EEPROM
+#define E2END 4095
+
+//#include <EEPROM.h>
+#include "../drivers/HAL_24LC.h"
 
 // Lower limit (fastest) step rate in uS for this platform
 // the exact model should be detected and these tailored to each, but this is a good starting point
@@ -13,9 +23,6 @@
 
 // Get this library from https://github.com/watterott/Arduino-Libs/archive/master.zip
 #include <digitalWriteFast.h>
-
-// This is defined for Arduino, but not for other platforms. We use a conservative value.
-#define E2END 2047
 
 // Interrupts
 #define cli() noInterrupts()

--- a/src/HAL/drivers/HAL_24LC.h
+++ b/src/HAL/drivers/HAL_24LC.h
@@ -3,11 +3,19 @@
 #include <Wire.h>
 #define PWire Wire
 
+// Default I2C address of the EEPROM
+#ifndef I2C_EEPROM_ADDRESS
+  #define I2C_EEPROM_ADDRESS 0x50
+  #warning "Using default I2C_EEPROM_ADDRESS. If you want to override it, define it in your HAL file"
+#endif
+
+#define I2C_CLOCK 400000
+
 class _eeprom {
 public:
   _eeprom() {
     PWire.begin();
-    PWire.setClock(400000);
+    PWire.setClock(I2C_CLOCK);
     lastWrite=millis();
   }
 
@@ -20,7 +28,7 @@ public:
       __firstCall=false;
     }
     
-    PWire.beginTransmission(80);
+    PWire.beginTransmission(I2C_EEPROM_ADDRESS);
     PWire.write((int)(address >> 8));   // msb
     PWire.write((int)(address & 0xFF)); // lsb
     PWire.write(data);
@@ -45,12 +53,12 @@ public:
       __firstCall=false;
     }
 
-    PWire.beginTransmission(80);
+    PWire.beginTransmission(I2C_EEPROM_ADDRESS);
     PWire.write((int)(address >> 8));   // msb
     PWire.write((int)(address & 0xFF)); // lsb
     PWire.endTransmission();
    
-    PWire.requestFrom(80,1);
+    PWire.requestFrom(I2C_EEPROM_ADDRESS,1);
     result = PWire.read();
     
     return result;
@@ -61,6 +69,5 @@ private:
 };
 
 _eeprom EEPROM;
-
 
 


### PR DESCRIPTION
STM32F103C8T6 Black Pill support. Preliminary. Includes changes to the I2C EEPROM HAL driver to be able to pass a different address for the EEPROM.