### PR TITLE
STM32 variants: CZ Mini board and Black Pill

### DIFF
--- a/Config.STM32Black.h
+++ b/Config.STM32Black.h
@@ -1,0 +1,213 @@
+// -----------------------------------------------------------------------------------
+// Configuration for OnStep on the STM32F103C8T6
+
+/*
+ * For more information on setting OnStep up see http://www.stellarjourney.com/index.php?r=site/equipment_onstep and 
+ * join the OnStep Groups.io at https://groups.io/g/onstep
+ * 
+ * See the Pins.STM32.h file for detailed information on this pin map to be sure it matches your wiring *** USE AT YOUR OWN RISK ***
+ *
+*/
+
+#define STM32_OFF   //  <- Turn _ON to use this configuration
+
+#ifdef STM32_ON
+// -------------------------------------------------------------------------------------------------------------------------
+// ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
+
+// Enables internal goto assist mount modeling (for Eq mounts), default=_OFF (Experimental)
+// Note that Goto Assist in Sky Planetarium works even if this is off
+#define ALIGN_GOTOASSIST_ON
+
+// Default speed for Serial1 and Serial4 com ports, Default=9600
+#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL4_BAUD_DEFAULT 9600
+
+// ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01
+// Pin ? (Aux1) for GPIO0 and Pin ? (Aux2) for Rst control.  Choose only one feature on Aux1/2.
+#define ESP8266_CONTROL_OFF
+
+// Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
+// _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)
+#define MOUNT_TYPE_GEM
+
+// Strict parking, default=_OFF.  Set to _ON and unparking is only allowed if successfully parked.  Otherwise unparking is allowed if at home and not parked (the Home/Reset command ":hF#" sets this state.) 
+#define STRICT_PARKING_OFF
+
+// ST4 interface on pins ?, ?, ?, ?.  Pin ? is RA- (West), Pin ? is Dec- (South), Pin ? is Dec+ (North), Pin ? is RA+ (East.)
+// ST4_ON enables the interface, ST4_PULLUP enables the interface and any internal pullup resistors.
+// It is up to you to create an interface that meets the electrical specifications of any connected device, use at your own risk.  default=_OFF
+#define ST4_OFF
+// If SEPARATE_PULSE_GUIDE_RATE_ON is used the ST4 port is limited to guide rates <= 1X except when ST4_HAND_CONTROL_ON is used.
+// Additionally, ST4_HAND_CONTROL_ON enables special features: Press and hold [E]+[W] buttons for > 2 seconds...  In this mode [E] decreases and [W] increases guide rates (or if tracking isn't on yet adjusts illuminated recticule brightness.)
+// [S] for Sync (or Accept if in align mode.) [N] for Tracking on/off. -OR- Press and hold [N]+[S] buttons for > 2 seconds...  In this mode [E] selects prior and [W] next user catalog item.
+// [N] to do a Goto to the catalog item.  [S] for Sound on/off.  The keypad returns to normal operation after 4 seconds of inactivity.  ST4_HAND_CONTROL_ON also adds a 100ms de-bounce to all button presses.
+// Finally, during a goto pressing any button aborts the slew.  If meridian flip paused at home, pressing any button continues.  default=_ON
+#define ST4_HAND_CONTROL_ON
+
+// Separate pulse-guide rate so centering and guiding don't disturb each other, default=_ON
+#define SEPARATE_PULSE_GUIDE_RATE_ON
+
+// Guide time limit (in seconds,) default=0 (no limit.)  A safety feature, some guides are started with one command and stopped with another.  
+// If the stop command is never received the guide will continue forever unless this is enabled.
+#define GUIDE_TIME_LIMIT 0
+
+// PPS use _ON or _PULLUP to enable the input and use the built-in pullup resistor.  Sense rising edge on Pin ? for optional precision clock source (GPS, for example), default=_OFF [infrequently used option]
+#define PPS_SENSE_OFF
+
+// PEC sense on Pin ? use _ON or _PULLUP to enable the input/use the built-in pullup resistor (digital input) or provide a comparison value (see below) for analog operation, default=_OFF
+// Analog values range from 0 to 1023 which indicate voltages from 0-3.3VDC on the analog pin, for example "PEC_SENSE 600" would detect an index when the voltage exceeds 1.93V
+// With either index detection method, once triggered 60s must expire before another detection can happen.  This gives time for the index magnet to pass by the detector before another cycle begins.
+// Ignored on Alt/Azm mounts.
+#define PEC_SENSE_OFF
+// PEC sense, rising edge (default with PEC_SENSE_STATE HIGH, use LOW for falling edge, ex. PEC_SENSE_ON) ; for optional PEC index
+#define PEC_SENSE_STATE HIGH
+
+// Switch close (to ground) on Pin ? for optional limit sense (stops gotos and/or tracking), default=_OFF
+#define LIMIT_SENSE_OFF
+
+// Light status LED by sink to ground (Pin ?), default=_ON.
+// _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash
+#define STATUS_LED_PINS_OFF
+// Light 2nd status LED by sink to ground (Pin ?), default=_OFF.
+// _ON sets this to blink at 1 sec intervals when PPS is synced.  Turns off if tracking is stopped.  Turns on during gotos.
+#define STATUS_LED2_PINS_OFF
+// Light reticule LED by sink to ground (Pin ?), default=_OFF.  (don't use with STATUS_LED2_PINS_ON)
+// RETICULE_LED_PINS n, where n=0 to 255 activates this feature and sets default brightness
+#define RETICULE_LED_PINS_OFF
+
+// Sound/buzzer on Pin ?, default=_OFF.
+// Specify frequency for a piezo speaker (for example "BUZZER 2000") or use BUZZER_ON for a piezo buzzer.
+#define BUZZER_OFF
+// Sound state at startup, default=_ON.
+#define DEFAULT_SOUND_ON
+
+// Optionally adjust tracking rate to compensate for atmospheric refraction, default=_OFF
+// can be turned on/off with the :Tr# and :Tn# commands regardless of this setting
+#define TRACK_REFRACTION_RATE_DEFAULT_ON
+
+// Set to _ON and OnStep will remember the last auto meridian flip setting (on/off), default=_OFF
+#define REMEMBER_AUTO_MERIDIAN_FLIP_ON
+
+// Set to _ON and OnStep will remember the last meridian flip pause at home setting (on/off), default=_OFF
+#define REMEMBER_PAUSE_HOME_ON
+
+// ADJUST THE FOLLOWING TO MATCH YOUR MOUNT --------------------------------------------------------------------------------
+#define REMEMBER_MAX_RATE_OFF        // set to _ON and OnStep will remember rates set in the ASCOM driver, Android App, etc. default=_OFF 
+#define MaxRate                   96 // microseconds per microstep default setting for gotos, can be adjusted for two times lower or higher at run-time
+                                     // minimum* (fastest goto) is around 16, default=96 higher is ok
+                                     // * = minimum can be lower, when both AXIS1/AXIS2_MICROSTEPS are used the compiler will warn you if it's too low
+
+#define DegreesForAcceleration   5.0 // approximate number of degrees for full acceleration or deceleration: higher values=longer acceleration/deceleration
+                                     // Default=5.0, too low (about <1) can cause gotos to never end if micro-step mode switching is enabled.
+#define DegreesForRapidStop      1.0 // approximate number of degrees required to stop when requested or if limit is exceeded during a slew: higher values=longer deceleration
+                                     // Default=1.0, too low (about <1) can cause gotos to never end if micro-step mode switching is enabled.
+
+#define BacklashTakeupRate        25 // backlash takeup rate (in multipules of the sidereal rate): too fast and your motors will stall,
+                                     // too slow and the mount will be sluggish while it moves through the backlash
+                                     // for the most part this doesn't need to be changed, but adjust when needed.  Default=25
+
+                                     // Axis1 is for RA/Az
+#define StepsPerDegreeAxis1  12800.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
+                                     // G11              :  400           * 32          * 1               *  360/360              = 12800
+                                     // Axis2 is for Dec/Alt
+#define StepsPerDegreeAxis2  12800.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
+                                     // G11              :  400           * 32          * 1               *  360/360              = 12800
+                                     
+                                     // PEC, number of steps for a complete worm rotation (in RA), (StepsPerDegreeAxis1*360)/gear_reduction2.  Ignored on Alt/Azm mounts.
+#define StepsPerWormRotationAxis1 12800L
+                                     // G11              : (12800*360)/360 = 12800
+
+#define PECBufferSize           824  // PEC, buffer size, max should be no more than 3384, your required buffer size >= StepsPerAxis1WormRotation/(StepsPerDegeeAxis1/240)
+                                     // for the most part this doesn't need to be changed, but adjust when needed.  824 seconds is the default.  Ignored on Alt/Azm mounts.
+
+#define MinutesPastMeridianE      30 // for goto's, how far past the meridian to allow before we do a flip (if on the East side of the pier) - a half hour of RA is the default = 30.  Sometimes used for Fork mounts in Align mode.  Ignored on Alt/Azm mounts.
+#define MinutesPastMeridianW      30 // as above, if on the West side of the pier.  If left alone, the mount will stop tracking when it hits the this limit.  Sometimes used for Fork mounts in Align mode.  Ignored on Alt/Azm mounts.
+                                     // The above two lines can be removed and settings in EEPROM will be used instead, be sure to set the Meridian limits in control software if you do this!  
+                                     // If you don't remove these lines Meridian limits will return to these defaults on power up.
+#define UnderPoleLimit            12 // maximum allowed hour angle (+/-) under the celestial pole.  Default=12.  Ignored on Alt/Azm mounts.
+                                     // If left alone, the mount will stop tracking when it hits this limit.  Valid range is 10 to 12 hours.
+#define MinDec                   -91 // minimum allowed declination, default = -91 (off)  Ignored on Alt/Azm mounts.
+#define MaxDec                   +91 // maximum allowed declination, default =  91 (off)  Ignored on Alt/Azm mounts.
+                                     // For example, a value of +80 would stop gotos/tracking near the north celestial pole.
+                                     // For a Northern Hemisphere user, this would stop tracking when the mount is in the polar home position but
+                                     // that can be easily worked around by doing an alignment once and saving a park position (assuming a 
+                                     // fork/yolk mount with meridian flips turned off by setting the minutesPastMeridian values to cover the whole sky)
+#define MaxAzm                   180 // Alt/Az mounts only. +/- maximum allowed Azimuth, default =  180.  Allowed range is 180 to 360
+
+// AXIS1/2 STEPPER DRIVER CONTROL ------------------------------------------------------------------------------------------
+// Axis1: Pins  ?, ? = Step,Dir (RA/Azm)
+// Axis2: Pins  ?, ? = Step,Dir (Dec/Alt)
+
+// Reverse the direction of movement.  Adjust as needed or reverse your wiring so things move in the right direction
+#define AXIS1_REVERSE_OFF            // RA/Azm axis
+#define AXIS2_REVERSE_OFF            // Dec/Alt axis
+
+// Stepper driver Enable support, just wire Enable to Pins ? (Axis1) and ? (Axis2) and OnStep will pull these HIGH to disable the stepper drivers on startup and when Parked or Homed.  
+// An Align, Sync, or Un-Park will enable the drivers.  Adjust below if you need these pulled LOW to disable the drivers.
+#define AXIS1_DISABLE HIGH
+#define AXIS2_DISABLE HIGH
+
+// For equatorial mounts, _ON powers down the Declination axis when it's not being used to help lower power use.  During low rate guiding (<=1x) the axis stays enabled
+// for 10 minutes after any guide on either axis.  Otherwise, the Dec axis is disabled (powered off) 10 seconds after movement stops.
+#define AXIS2_AUTO_POWER_DOWN_OFF
+
+// Basic stepper driver mode setup . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+// If used, this requires connections M0, M1, and M2 on Pins ?,?,? for Axis1 (RA/Azm) and Pins ?,?,? for Axis2 (Dec/Alt.)
+// Stepper driver models are as follows: (for example AXIS1_DRIVER_MODEL DRV8825,) A4988, LV8729, RAPS128, TMC2208, TMC2130 (spreadCycle,) 
+// TMC2130_QUIET (stealthChop tracking,) TMC2130_VQUIET (full stealthChop mode,) add _LOWPWR for 50% power during tracking (for example: TMC2130_QUIET_LOWPWR)
+#define AXIS1_DRIVER_MODEL_OFF      // Axis1 (RA/Azm):  Default _OFF, Stepper driver model (see above)
+#define AXIS1_MICROSTEPS_OFF        // Axis1 (RA/Azm):  Default _OFF, Microstep mode when the scope is doing sidereal tracking (for example: AXIS1_MICROSTEPS 32)
+#define AXIS1_MICROSTEPS_GOTO_OFF   // Axis1 (RA/Azm):  Default _OFF, Optional microstep mode used during gotos (for example: AXIS1_MICROSTEPS_GOTO 2)
+#define AXIS2_DRIVER_MODEL_OFF      // Axis2 (Dec/Alt): Default _OFF, Stepper driver model (see above)
+#define AXIS2_MICROSTEPS_OFF        // Axis2 (Dec/Alt): Default _OFF, Microstep mode when the scope is doing sidereal tracking
+#define AXIS2_MICROSTEPS_GOTO_OFF   // Axis2 (Dec/Alt): Default _OFF, Optional microstep mode used during gotos
+// Note: you can replace this section with the contents of "AdvancedStepperSetup.txt" . . . . . . . . . . . . . . . . . . . 
+
+// Stepper driver Fault detection on Pins ? (Aux1) and ? (Aux2,) choose only one feature to use on Aux1/2.  The SPI interface (on M0/M1/M2/Aux) can be used to detect errors on the TMC2130.
+// other settings are LOW, HIGH, TMC2130 (if available applies internal pullup if LOW and pulldown if HIGH.)
+#define AXIS1_FAULT_OFF
+#define AXIS2_FAULT_OFF
+
+// ------------------------------------------------------------------------------------------------------------------------
+// THE FOLLOWING ARE INFREQUENTLY USED OPTIONS FOR THE MINIPCB SINCE USING ANY OF THESE WOULD REQUIRE SOLDERING TO THE PCB BACK AND ADDING OFF-PCB CIRCUITRY, MUCH EASIER TO USE A MAXPCB AND TEENSY3.5/3.6
+// FOCUSER ROTATOR OR ALT/AZ DE-ROTATION ----------------------------------------------------------------------------------
+// Pins ?,? = Step,Dir (choose either this option or the second focuser, not both)
+#define ROTATOR_OFF                  // enable or disable rotator feature (for any mount type,) default=_OFF (de-rotator is available only for MOUNT_TYPE_ALTAZM.) [infrequently used option]
+#define MaxRateAxis3               8 // this is the minimum number of milli-seconds between micro-steps, default=8
+#define StepsPerDegreeAxis3     64.0 // calculated as    :  stepper_steps * micro_steps * gear_reduction1 * (gear_reduction2/360)
+                                     // Rotator          :  24            * 8           * 20              *  6/360                = 64
+                                     // For de-rotation of Alt/Az mounts a quick estimate of the required resolution (in StepsPerDegree)
+                                     // would be an estimate of the circumference of the useful imaging circle in (pixels * 2)/360
+#define AXIS3_REVERSE_OFF            // reverse the direction of Axis3 rotator movement
+#define AXIS3_DISABLE_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
+#define MinAxis3                -180 // minimum allowed Axis3 rotator, default = -180
+#define MaxAxis3                 180 // maximum allowed Axis3 rotator, default =  180
+
+// FOCUSER1 ---------------------------------------------------------------------------------------------------------------
+// Pins ?,? = Step,Dir
+#define FOCUSER1_OFF                 // enable or disable focuser feature, default=_OFF
+#define MaxRateAxis4               8 // this is the minimum number of milli-seconds between micro-steps, default=8
+#define StepsPerMicrometerAxis4  0.5 // figure this out by testing or other means
+#define AXIS4_REVERSE_OFF            // reverse the direction of Axis4 focuser movement
+#define AXIS4_DISABLE_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
+#define MinAxis4               -25.0 // minimum allowed Axis4 position in millimeters, default = -25.0
+#define MaxAxis4                25.0 // maximum allowed Axis4 position in millimeters, default =  25.0
+
+// FOCUSER2 ---------------------------------------------------------------------------------------------------------------
+// Pins ?,? = Step,Dir (choose either this option or the rotator, not both)
+#define FOCUSER2_OFF                 // enable or disable focuser feature, default=_OFF
+#define MaxRateAxis5               8 // this is the minimum number of milli-seconds between micro-steps, default=8
+#define StepsPerMicrometerAxis5  0.5 // figure this out by testing or other means
+#define AXIS5_REVERSE_OFF            // reverse the direction of Axis5 focuser movement
+#define AXIS5_DISABLE_OFF            // Pin ?.  Use HIGH for common stepper drivers if you want to power down the motor at stand-still.  Default _OFF.
+#define MinAxis5               -25.0 // minimum allowed Axis5 position in millimeters, default = -25.0
+#define MaxAxis5                25.0 // maximum allowed Axis5 position in millimeters, default =  25.0
+
+// THAT'S IT FOR USER CONFIGURATION!
+
+// -------------------------------------------------------------------------------------------------------------------------
+#define FileVersionConfig 2
+#include "src/pinmaps/Pins.STM32Black.h"
+#endif
+

--- a/Config.STM32Black.h
+++ b/Config.STM32Black.h
@@ -9,9 +9,9 @@
  *
 */
 
-#define STM32_OFF   //  <- Turn _ON to use this configuration
+#define STM32Black_OFF   //  <- Turn _ON to use this configuration
 
-#ifdef STM32_ON
+#ifdef STM32Black_ON
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/Config.STM32CZ.h
+++ b/Config.STM32CZ.h
@@ -208,6 +208,6 @@
 
 // -------------------------------------------------------------------------------------------------------------------------
 #define FileVersionConfig 2
-#include "src/pinmaps/Pins.STM32.h"
+#include "src/pinmaps/Pins.STM32CZ.h"
 #endif
 

--- a/Config.STM32CZ.h
+++ b/Config.STM32CZ.h
@@ -9,7 +9,7 @@
  *
 */
 
-#define STM32CZ_ON    //  <- Turn _ON to use this configuration
+#define STM32CZ_OFF    //  <- Turn _ON to use this configuration
 
 #ifdef STM32CZ_ON
 // -------------------------------------------------------------------------------------------------------------------------

--- a/Config.STM32CZ.h
+++ b/Config.STM32CZ.h
@@ -9,9 +9,9 @@
  *
 */
 
-#define STM32_OFF   //  <- Turn _ON to use this configuration
+#define STM32CZ_ON    //  <- Turn _ON to use this configuration
 
-#ifdef STM32_ON
+#ifdef STM32CZ_ON
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -57,7 +57,8 @@
 #include "Config.Ramps14.h"
 #include "Config.Mega2560Alt.h"
 #include "Config.TM4C.h"
-#include "Config.STM32.h"
+#include "Config.STM32CZ.h"
+#include "Config.STM32Black.h"
 #include "Validate.h"
 
 #include "src/HAL/HAL.h"

--- a/Validate.h
+++ b/Validate.h
@@ -41,7 +41,14 @@
     #define Configuration_Found
   #endif
 #endif
-#ifdef STM32_ON
+#ifdef STM32CZ_ON
+  #ifdef Configuration_Found
+    #define Configuration_Duplicate
+  #else
+    #define Configuration_Found
+  #endif
+#endif
+#ifdef STM32Black_ON
   #ifdef Configuration_Found
     #define Configuration_Duplicate
   #else

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -12,8 +12,7 @@
 // End of EEPROM
 #define E2END 4095
 
-//#include <EEPROM.h>
-#include "../drivers/HAL_24LC.h"
+#include "../drivers/NV_I2C_EEPROM.h"
 
 // Lower limit (fastest) step rate in uS for this platform
 // the exact model should be detected and these tailored to each, but this is a good starting point

--- a/src/HAL/drivers/NV_I2C_EEPROM.h
+++ b/src/HAL/drivers/NV_I2C_EEPROM.h
@@ -1,3 +1,4 @@
+
 // non-volatile storage
 
 // Check if file was included
@@ -113,38 +114,32 @@ private:
   void nvs_i2c_ee_write(uint16_t address, uint8_t data) {
 
     Wire.beginTransmission(_eeprom_addr);
-    if (Wire.endTransmission()==0) {
-        Wire.beginTransmission(_eeprom_addr);
-        Wire.write(address >> 8);
-        Wire.write(address & 0xFF);
-        Wire.write(data);
-        Wire.endTransmission();
-        delay(3);
-    }
-
+    Wire.write(address >> 8);
+    Wire.write(address & 0xFF);
+    Wire.write(data);
+    Wire.endTransmission();
+    
+    delay(3);
   }
 
   uint8_t nvs_i2c_ee_read(uint16_t address) {
       
-    uint8_t result = 0;
-    int r = 0;
-    
+    uint8_t result = 0xFF;
+
     Wire.beginTransmission(_eeprom_addr);
-    if (Wire.endTransmission() == 0) {   
-        Wire.beginTransmission(_eeprom_addr);
-        Wire.write(address >> 8);
-        Wire.write(address & 0xFF);
-        if (Wire.endTransmission() == 0) {
-          Wire.requestFrom(_eeprom_addr, 1);
-          while (Wire.available() > 0 && r<1) {
-            result = (byte)Wire.read();
-            r++;
-          }
-        }
+    Wire.write(address >> 8);
+    Wire.write(address & 0xFF);
+    Wire.endTransmission();
+ 
+    Wire.requestFrom(_eeprom_addr, 1);
+ 
+    if (Wire.available()) {
+      result = Wire.read();
     }
+ 
     return result;
   }
-  
 };
 
 #endif
+

--- a/src/HAL/drivers/NV_I2C_EEPROM.h
+++ b/src/HAL/drivers/NV_I2C_EEPROM.h
@@ -111,33 +111,33 @@ private:
   // Address of the I2C EEPROM
   uint8_t _eeprom_addr;
 
-  void nvs_i2c_ee_write(uint16_t address, uint8_t data) {
+  void nvs_i2c_ee_write(uint16_t offset, uint8_t data) {
 
     Wire.beginTransmission(_eeprom_addr);
-    Wire.write(address >> 8);
-    Wire.write(address & 0xFF);
+    Wire.write(offset >> 8);
+    Wire.write(offset & 0xFF);
     Wire.write(data);
     Wire.endTransmission();
     
     delay(3);
   }
 
-  uint8_t nvs_i2c_ee_read(uint16_t address) {
+  uint8_t nvs_i2c_ee_read(uint16_t offset) {
       
-    uint8_t result = 0xFF;
+    uint8_t data = 0xFF;
 
     Wire.beginTransmission(_eeprom_addr);
-    Wire.write(address >> 8);
-    Wire.write(address & 0xFF);
+    Wire.write(offset >> 8);
+    Wire.write(offset & 0xFF);
     Wire.endTransmission();
  
     Wire.requestFrom(_eeprom_addr, 1);
  
     if (Wire.available()) {
-      result = Wire.read();
+      data = Wire.read();
     }
  
-    return result;
+    return data;
   }
 };
 

--- a/src/HAL/drivers/NV_I2C_EEPROM.h
+++ b/src/HAL/drivers/NV_I2C_EEPROM.h
@@ -111,29 +111,40 @@ private:
   uint8_t _eeprom_addr;
 
   void nvs_i2c_ee_write(uint16_t address, uint8_t data) {
-    
-    delay(3);
+
     Wire.beginTransmission(_eeprom_addr);
-    Wire.write((int)(address >> 8));   // msb
-    Wire.write((int)(address & 0xFF)); // lsb
-    Wire.write(data);
-    Wire.endTransmission();
+    if (Wire.endTransmission()==0) {
+        Wire.beginTransmission(_eeprom_addr);
+        Wire.write(address >> 8);
+        Wire.write(address & 0xFF);
+        Wire.write(data);
+        Wire.endTransmission();
+        delay(3);
+    }
+
   }
 
   uint8_t nvs_i2c_ee_read(uint16_t address) {
-    uint8_t result = 0xFF;
+      
+    uint8_t result = 0;
+    int r = 0;
     
-    delay(3);
     Wire.beginTransmission(_eeprom_addr);
-    Wire.write((int)(address >> 8));   // msb
-    Wire.write((int)(address & 0xFF)); // lsb
-    Wire.endTransmission();
-    Wire.requestFrom(_eeprom_addr, 1);
-    result = Wire.read();
-
+    if (Wire.endTransmission() == 0) {   
+        Wire.beginTransmission(_eeprom_addr);
+        Wire.write(address >> 8);
+        Wire.write(address & 0xFF);
+        if (Wire.endTransmission() == 0) {
+          Wire.requestFrom(_eeprom_addr, 1);
+          while (Wire.available() > 0 && r<1) {
+            result = (byte)Wire.read();
+            r++;
+          }
+        }
+    }
     return result;
   }
+  
 };
 
 #endif
-

--- a/src/HAL/drivers/NV_I2C_EEPROM.h
+++ b/src/HAL/drivers/NV_I2C_EEPROM.h
@@ -1,0 +1,139 @@
+// non-volatile storage
+
+// Check if file was included
+#ifndef _NV_H_
+#define _NV_H_
+
+#include <Wire.h>
+
+#define I2C_CLOCK 400000
+
+// I2C EEPROM Address on DS3231 RTC module
+#define I2C_EEPROM_ADDRESS 0x57
+
+// I2C EEPROM on DS3231 is 32 kilobits = 4 KiloBytes
+#define E2END 4095
+
+class nvs {
+  public:    
+    void init() {
+      Wire.begin();
+      Wire.setClock(I2C_CLOCK);
+      _eeprom_addr = I2C_EEPROM_ADDRESS;
+    }
+
+    uint8_t read(uint16_t i) {
+      return nvs_i2c_ee_read(i);
+    }
+
+    void update(uint16_t i, uint8_t j) {
+      write(i,j);
+    }
+
+    void write(uint16_t i, uint8_t j) {
+      nvs_i2c_ee_write(i,j);
+    }
+
+    // write int numbers into EEPROM at position i (2 uint8_ts)
+    void writeInt(uint16_t i, uint16_t j) {
+      uint8_t *k = (uint8_t*)&j;
+      update(i+0,*k); k++;
+      update(i+1,*k);
+    }
+    
+    // read int numbers from EEPROM at position i (2 uint8_ts)
+    int readInt(uint16_t i) {
+      uint16_t j;
+      uint8_t *k = (uint8_t*)&j;
+      *k=read(i+0); k++;
+      *k=read(i+1);
+      return j;
+    }
+
+    // write 4 uint8_t long into EEPROM at position i (4 uint8_ts)
+    void writeLong(uint16_t i,long l) {
+      writeQuad(i,(uint8_t*)&l);
+    }
+    
+    // read 4 uint8_t long from EEPROM at position i (4 uint8_ts)
+    long readLong(uint16_t i) {
+      long l;
+      readQuad(i,(uint8_t*)&l);
+      return l;
+    }
+            
+    // write 4 uint8_t float into EEPROM at position i (4 uint8_ts)
+    void writeFloat(uint16_t i,float f) {
+      writeQuad(i,(uint8_t*)&f);
+    }
+    
+    // read 4 uint8_t float from EEPROM at position i (4 uint8_ts)
+    float readFloat(uint16_t i) {
+      float f;
+      readQuad(i,(uint8_t*)&f);
+      return f;
+    }
+
+    // write 4 uint8_t variable into EEPROM at position i (4 uint8_ts)
+    void writeQuad(uint16_t i,uint8_t *v) {
+      update(i+0,*v); v++;
+      update(i+1,*v); v++;
+      update(i+2,*v); v++;
+      update(i+3,*v);
+    }
+    
+    // read 4 uint8_t variable from EEPROM at position i (4 uint8_ts)
+    void readQuad(uint16_t i,uint8_t *v) {
+      *v=read(i+0); v++;
+      *v=read(i+1); v++;
+      *v=read(i+2); v++;
+      *v=read(i+3);  
+    }
+    
+    // write String into EEPROM at position i (16 uint8_ts)
+    void writeString(uint16_t i, char l[]) {
+      int l1;
+      for (l1=0; l1<16; l1++) {
+        update(i+l1,*l); l++;
+      }
+    }
+    
+    // read String from EEPROM at position i (16 uint8_ts)
+    void readString(uint16_t i,  char l[]) {
+      int l1;
+      for (l1=0; l1<16; l1++) {
+        *l=read(i+l1); l++;
+      }
+    }
+
+private:
+  // Address of the I2C EEPROM
+  uint8_t _eeprom_addr;
+
+  void nvs_i2c_ee_write(uint16_t address, uint8_t data) {
+    
+    delay(3);
+    Wire.beginTransmission(_eeprom_addr);
+    Wire.write((int)(address >> 8));   // msb
+    Wire.write((int)(address & 0xFF)); // lsb
+    Wire.write(data);
+    Wire.endTransmission();
+  }
+
+  uint8_t nvs_i2c_ee_read(uint16_t address) {
+    uint8_t result = 0xFF;
+    
+    delay(3);
+    Wire.beginTransmission(_eeprom_addr);
+    Wire.write((int)(address >> 8));   // msb
+    Wire.write((int)(address & 0xFF)); // lsb
+    Wire.endTransmission();
+    Wire.requestFrom(_eeprom_addr, 1);
+    result = Wire.read();
+
+    return result;
+  }
+};
+
+#endif
+

--- a/src/lib/NV.h
+++ b/src/lib/NV.h
@@ -1,6 +1,10 @@
 // -----------------------------------------------------------------------------------
 // non-volatile storage
 
+// Check if a file was included in HAL
+#ifndef _NV_H_
+#define _NV_H_
+
 #pragma once
 
 #include "EEPROM.h"
@@ -94,3 +98,4 @@ class nvs {
 
 };
 
+#endif

--- a/src/pinmaps/Pins.STM32Black.h
+++ b/src/pinmaps/Pins.STM32Black.h
@@ -17,7 +17,7 @@
 // STM32103RC: 72MHz, 256K flash, 48K RAM
 // STM32103RE: 72MHz, 512K flash, 64K RAM
 
-#if defined(__ARM_STM32__)
+#if defined(__STM32F1__)
 
 // The pins here are not tested yet, and need to change 
 

--- a/src/pinmaps/Pins.STM32CZ.h
+++ b/src/pinmaps/Pins.STM32CZ.h
@@ -1,0 +1,86 @@
+// -------------------------------------------------------------------------------------------------
+// Pin map for OnStep on STM32
+// 
+// This pin map is for an STM32F103C8T6 "Black Pill" stick.
+// It runs at 72MHz has 128K flash and 20K RAM, and is 3.3V only
+//
+// Cost on eBay and AliExpress is less than US $2.50
+// More info, schematic at:
+//   http://wiki.stm32duino.com/index.php?title=Black_Pill
+//
+// Other boards based on the following chips also have enough flash
+// and RAM for OnStep, and should work, with pin modifications.
+//
+// STM32103VC: 72MHz, 256K flash, 48K RAM
+// STM32103VE: 72MHz, 512K flash, 64K RAM
+// STM32103ZE: 72MHz, 512K flash, 64K RAM
+// STM32103RC: 72MHz, 256K flash, 48K RAM
+// STM32103RE: 72MHz, 512K flash, 64K RAM
+
+#if defined(__STM32F1__)
+
+// The pins here are not tested yet, and need to change 
+
+#define Axis1_EN        PD14   // Enable
+#define Axis1_M0        PD12   // Microstep Mode 0
+#define Axis1_M1        PD10   // Microstep Mode 1
+#define Axis1_M2        PD8    // Microstep Mode 2
+#define Axis1StepPin    PB14   // Step
+#define Axis1DirPin     PB12   // Motor Direction
+//#define Axis1_FAULT   Undefined    // Fault
+//#define Axis1_Aux     Axis1_Aux    // Aux - ESP8266 GPIO0 or SPI MISO
+
+#define Axis2_EN        PA5    // Enable
+#define Axis2_M0        PA4    // Microstep Mode 0
+#define Axis2_M1        PA3    // Microstep Mode 1
+#define Axis2_M2        PA2    // Microstep Mode 2
+#define Axis2StepPin    PA1    // Step
+#define Axis2DirPin     PA0    // Motor Direction
+//#define Axis2_FAULT   Undefined    // Fault
+//#define Axis2_Aux     Axis2_FAULT  // Aux - ESP8266 RST or SPI MISO
+
+// This is the built in LED for the Black Pill board. There is a pin
+// available from it too, in case you want to power another LED with a wire
+#define LEDnegPin       PE6          // Drain
+//#define LEDneg2Pin    Undefined    // Drain
+//#define ReticulePin   Undefined    // Drain
+
+// For a piezo buzzer
+#define TonePin         PA8  // Tone
+
+// ST4 interface
+#define ST4DEn          PB13  // ST4 DE+ North
+#define ST4DEs          PB14  // ST4 DE- South
+#define ST4RAw          PB15  // ST4 RA- West
+#define ST4RAe          PA8   // ST4 RA+ East
+
+// Pins to focuser1 stepper driver
+#define Axis4DirPin     A15    // Dir
+#define Axis4StepPin    PB3    // Step
+
+// For rotator stepper driver
+#define Axis3DirPin     PB4    // Dir
+#define Axis3StepPin    PB5    // Step
+
+// For focuser2 stepper driver
+//#define Axis5DirPin   Undefined    // Dir
+//#define Axis5StepPin  Undefined    // Step
+
+// The limit switch sense is a logic level input which uses the internal pull up,
+// shorted to ground it stops gotos/tracking
+//#define LimitPin      Undefined   
+
+// The PEC index sense is a logic level input, resets the PEC index on rising
+// edge then waits for 60 seconds before allowing another reset
+//#define PecPin       Undefined
+//#define AnalogPecPin Undefined    // PEC Sense, analog or digital
+
+// The PPS pin is a 3.3V logic input, OnStep measures time between rising edges and
+// adjusts the internal sidereal clock frequency
+//#define PpsPin       Undefined    // Pulse Per Second time source, e.g. GPS
+
+#else
+#error "Wrong processor for this configuration!"
+
+#endif
+


### PR DESCRIPTION
Added different pinouts for CZ Mini (STM32F103VE) and Black Pill (STM32F103C8). The former has quite a few more pins than the latter. Some pin names do not even exist in the other (due to having the pins in groups, A, B, C, ...etc., and medium density MCU not having them all).

Also added here is a self contained NV API for I2C EEPROM. It does not require including EEPROM.h, like HAL_24LC.h does. EEPROM.h on STM32 is flash emulation and that confuses things. The NV_I2C_EEPROME preserves the behaviour for other platforms. The NV.h file will be included, but none of the code in it will be preprocessed nor compiled, just like system headers have checks to not include files more than once. 

The NV_I2C_EEPROM works with a standalone test program that prints the contents of EEPROM and then writes to a few locations, and reads them back. 

When using it with OnStep, it crashes on the CZ Mini board (the watchdog LED flashes fast). No idea why and can't be debugged since this triggered by 'nvs nv;' which is very early and I can't do Serial.print() at that point. 