### PR TITLE
Fix Library.h to not call nv.* before nv.init() is done.

### DIFF
--- a/OnStep.ino
+++ b/OnStep.ino
@@ -113,9 +113,12 @@ weather ambient;
 #define initKey 915307548 // unique identifier for the current initialization format, do not change
 
 void setup() {
-  // be sure non-volatile memory is ready to go
+  // Initialize the Non-Volatile Memory
   nv.init();
 
+  // Initialize the Object Library
+  Lib.Init();
+  
   // get weather monitoring ready to go
   ambient.init();
   

--- a/src/HAL/drivers/NV_I2C_EEPROM.h
+++ b/src/HAL/drivers/NV_I2C_EEPROM.h
@@ -113,18 +113,33 @@ private:
 
   void nvs_i2c_ee_write(uint16_t offset, uint8_t data) {
 
+    //Serial.print("nvs write: offset=");
+    //Serial.print(offset, HEX);
+    //Serial.print(", data=");
+    //Serial.print(data, HEX);
+
+    delay(5);
+
     Wire.beginTransmission(_eeprom_addr);
     Wire.write(offset >> 8);
     Wire.write(offset & 0xFF);
     Wire.write(data);
+
     Wire.endTransmission();
-    
-    delay(3);
+
+    delay(5);
+
+    //Serial.println(" Done");
   }
 
   uint8_t nvs_i2c_ee_read(uint16_t offset) {
       
     uint8_t data = 0xFF;
+
+    //Serial.print("nvs read: offset=");
+    //Serial.print(offset, HEX);
+
+    delay(5);
 
     Wire.beginTransmission(_eeprom_addr);
     Wire.write(offset >> 8);
@@ -133,10 +148,11 @@ private:
  
     Wire.requestFrom(_eeprom_addr, 1);
  
-    if (Wire.available()) {
-      data = Wire.read();
-    }
+    data = Wire.read();
  
+    //Serial.print(", data=");
+    //Serial.print(data, HEX);
+
     return data;
   }
 };

--- a/src/lib/Library.h
+++ b/src/lib/Library.h
@@ -26,6 +26,8 @@ class Library
     Library();
     ~Library();
     
+    void Init();
+
     boolean setCatalog(int num);
 
     // 16 byte record
@@ -78,12 +80,17 @@ Library::Library()
   bytePos=byteMin;
   
   recMax=byteCount/rec_size;           // maximum number of records
-
-  firstRec();
 }
 
 Library::~Library()
 {
+}
+
+void Library::Init() {
+  // This is now in the Init() function, because on boards
+  // with an I2C EEPROM nv.init() has to be called before
+  // anything else
+  firstRec();
 }
 
 boolean Library::setCatalog(int num)


### PR DESCRIPTION
I found why the issue with the I2C EEPROM happens:

The reason is that Library.h calls calls firstRec in its constructor, that calls a bunch of stuff that ends up calling nv.write() and nv.read(). And the Library object is instantiated right in Library.h.

So, this means that including Library.h calls EEPROM reads. However, Wire.begin() and the custom address of the EEPROM are only called in nv.init(), which happens in setup(), way after Lib is instantiated.

Moving Wire.begin() to the constructor of the nvs class does not work for some reason.

Now Library.h has its own .Init() and it is called in setup() AFTER nv.init() is called. 

Still have a problem with nv.write(). Wire.endTransmission() never returns for an unknown reason. 