### PR TITLE
More descriptive naming in the code: rename PSerial1 to SerialWiFi

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -9,14 +9,14 @@ unsigned long _coord_t=0;
 double _dec,_ra;
 
 // help with commands
-enum Command {COMMAND_NONE, COMMAND_SERIAL, COMMAND_SERIAL1, COMMAND_SERIAL4, COMMAND_SERIALST4, COMMAND_SERIALX};
+enum Command {COMMAND_NONE, COMMAND_SERIAL, COMMAND_SERIAL_WIFI, COMMAND_SERIAL4, COMMAND_SERIALST4, COMMAND_SERIALX};
 char reply[50];
 char command[3];
 char parameter[25];
 boolean commandError = false;
 boolean quietReply   = false;
 cb cmd;  // the first Serial is always enabled
-#ifdef HAL_SERIAL1_ENABLED
+#ifdef HAL_SERIAL_WIFI_ENABLED
 cb cmd1;
 #endif
 #ifdef HAL_SERIAL4_ENABLED
@@ -43,8 +43,8 @@ void processCommands() {
 
     // accumulate the command
     if ((PSerial.available()>0) && (!cmd.ready())) cmd.add(PSerial.read());
-#ifdef HAL_SERIAL1_ENABLED
-    if ((PSerial1.available()>0) && (!cmd1.ready())) cmd1.add(PSerial1.read());
+#ifdef HAL_SERIAL_WIFI_ENABLED
+    if ((SerialWiFi.available()>0) && (!cmd1.ready())) cmd1.add(SerialWiFi.read());
 #endif
 #ifdef HAL_SERIAL4_ENABLED
     if ((PSerial4.available()>0) && (!cmd4.ready())) cmd4.add(PSerial4.read());
@@ -56,8 +56,8 @@ void processCommands() {
     // send any reply
 #ifdef HAL_SERIAL_TRANSMIT
     if (PSerial.transmit()) return;
-  #ifdef HAL_SERIAL1_ENABLED
-    if (PSerial1.transmit()) return;
+  #ifdef HAL_SERIAL_WIFI_ENABLED
+    if (SerialWiFi.transmit()) return;
   #endif
   #ifdef HAL_SERIAL4_ENABLED
     if (PSerial4.transmit()) return;
@@ -67,8 +67,8 @@ void processCommands() {
     // if a command is ready, process it
     Command process_command = COMMAND_NONE;
     if (cmd.ready()) { strcpy(command,cmd.getCmd()); strcpy(parameter,cmd.getParameter()); cmd.flush(); process_command=COMMAND_SERIAL; }
-#ifdef HAL_SERIAL1_ENABLED
-    else if (cmd1.ready()) { strcpy(command,cmd1.getCmd()); strcpy(parameter,cmd1.getParameter()); cmd1.flush(); process_command=COMMAND_SERIAL1; }
+#ifdef HAL_SERIAL_WIFI_ENABLED
+    else if (cmd1.ready()) { strcpy(command,cmd1.getCmd()); strcpy(parameter,cmd1.getParameter()); cmd1.flush(); process_command=COMMAND_SERIAL_WIFI; }
 #endif
 #ifdef HAL_SERIAL4_ENABLED
     else if (cmd4.ready()) { strcpy(command,cmd4.getCmd()); strcpy(parameter,cmd4.getParameter()); cmd4.flush(); process_command=COMMAND_SERIAL4; }
@@ -1258,14 +1258,14 @@ void processCommands() {
             #endif
             delay(50); PSerial.begin(baudRate[i]);
             quietReply=true; 
-#ifdef HAL_SERIAL1_ENABLED
+#ifdef HAL_SERIAL_WIFI_ENABLED
           } else
-          if (process_command==COMMAND_SERIAL1) {
-            PSerial1.print("1"); 
+          if (process_command==COMMAND_SERIAL_WIFI) {
+            SerialWiFi.print("1"); 
             #ifdef HAL_SERIAL_TRANSMIT
-            while (PSerial1.transmit()); 
+            while (SerialWiFi.transmit()); 
             #endif
-            delay(50); PSerial1.begin(baudRate[i]); 
+            delay(50); SerialWiFi.begin(baudRate[i]); 
             quietReply=true;
 #endif
 #ifdef HAL_SERIAL4_ENABLED
@@ -1897,11 +1897,11 @@ void processCommands() {
           PSerial.print(reply);
         } 
   
-#ifdef HAL_SERIAL1_ENABLED
-        if (process_command==COMMAND_SERIAL1) {
+#ifdef HAL_SERIAL_WIFI_ENABLED
+        if (process_command==COMMAND_SERIAL_WIFI) {
           if (cmd1.checksum) checksum(reply);
           if (!supress_frame) strcat(reply,"#");
-          PSerial1.print(reply);
+          SerialWiFi.print(reply);
         }
 #endif
 

--- a/Config.Classic.h
+++ b/Config.Classic.h
@@ -21,7 +21,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_WIFI_BAUD_DEFAULT 9600
 
 // Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
 // _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)

--- a/Config.MaxPCB.h
+++ b/Config.MaxPCB.h
@@ -20,7 +20,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 and Serial4 com ports, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_WIFI_BAUD_DEFAULT 9600
 #define SERIAL4_BAUD_DEFAULT 9600
 
 // ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01

--- a/Config.Mega2560Alt.h
+++ b/Config.Mega2560Alt.h
@@ -17,7 +17,7 @@
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_WIFI_BAUD_DEFAULT 9600
 
 // Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
 // _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)

--- a/Config.MiniPCB.h
+++ b/Config.MiniPCB.h
@@ -20,7 +20,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_WIFI_BAUD_DEFAULT 9600
 
 // ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01
 // Pin 18 (Aux1) for GPIO0 and Pin 5 (Aux2) for Rst control.  Choose only one feature on Aux1/2.

--- a/Config.Ramps14.h
+++ b/Config.Ramps14.h
@@ -26,7 +26,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_WIFI_BAUD_DEFAULT 9600
 
 // Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
 // _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)

--- a/Config.STM32.h
+++ b/Config.STM32.h
@@ -12,7 +12,7 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * * * * *
 */
 
-#define STM32Black_OFF   //  <- Turn _ON to use STM32F103C8T6 Black with this configuration OR
+#define STM32Black_ON    //  <- Turn _ON to use STM32F103C8T6 Black with this configuration OR
 #define STM32CZ_OFF      //  <- Turn _ON to use STM32F103VET6 CZ with this configuration
 
 #if defined(STM32Black_ON) || defined(STM32CZ_ON)
@@ -24,7 +24,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 and Serial4 com ports, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_WIFI_BAUD_DEFAULT 9600
 #define SERIAL4_BAUD_DEFAULT 9600
 
 // ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01

--- a/Config.TM4C.h
+++ b/Config.TM4C.h
@@ -22,7 +22,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 and Serial4 com ports, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_WIFI_BAUD_DEFAULT 9600
 #define SERIAL4_BAUD_DEFAULT 9600
 
 // ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -159,8 +159,8 @@ void setup() {
   Init_Start_Timers();
 
   PSerial.begin(9600);
-#ifdef HAL_SERIAL1_ENABLED
-  PSerial1.begin(SERIAL1_BAUD_DEFAULT);
+#ifdef HAL_SERIAL_WIFI_ENABLED
+  SerialWiFi.begin(SERIAL_WIFI_BAUD_DEFAULT);
 #endif
 #ifdef HAL_SERIAL4_ENABLED
   PSerial4.begin(SERIAL4_BAUD_DEFAULT);

--- a/Validate.h
+++ b/Validate.h
@@ -204,8 +204,8 @@
 #endif
 
 // set serial port baud rate if not done so already
-#ifndef SERIAL1_BAUD_DEFAULT
-  #define SERIAL1_BAUD_DEFAULT 9600
+#ifndef SERIAL_WIFI_BAUD_DEFAULT
+  #define SERIAL_WIFI_BAUD_DEFAULT 9600
 #endif
 #ifndef SERIAL4_BAUD_DEFAULT
   #define SERIAL4_BAUD_DEFAULT 9600

--- a/src/HAL/HAL_Due/HAL_Due.h
+++ b/src/HAL/HAL_Due/HAL_Due.h
@@ -8,9 +8,9 @@
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 #define PSerial Serial
-#define PSerial1 Serial1
+#define SerialWiFi Serial1
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define HAL_SERIAL_WIFI_ENABLED
 
 // New symbol for the default I2C port ---------------------------------------------------------------
 #define HAL_Wire Wire

--- a/src/HAL/HAL_Mega2560/HAL_Mega2560.h
+++ b/src/HAL/HAL_Mega2560/HAL_Mega2560.h
@@ -14,7 +14,7 @@
 // Use low overhead serial
 #include "HAL_Serial.h"
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define HAL_SERIAL_WIFI_ENABLED
 // this tells OnStep that a .transmit() method needs to be called to send data
 #define HAL_SERIAL_TRANSMIT
 

--- a/src/HAL/HAL_Mega2560/HAL_Serial.h
+++ b/src/HAL/HAL_Mega2560/HAL_Serial.h
@@ -175,7 +175,7 @@ class pserial1 {
 };
 
 pserial PSerial;
-pserial1 PSerial1;
+pserial1 SerialWiFi;
 
 // UART Receive Complete Interrupt Handler for Serial0
 ISR(USART0_RX_vect)  {
@@ -185,6 +185,6 @@ ISR(USART0_RX_vect)  {
 
 // UART Receive Complete Interrupt Handler for Serial1
 ISR(USART1_RX_vect)  {
-  PSerial1._recv_buffer[PSerial1._recv_tail]=UDR1; 
-  PSerial1._recv_tail++; // buffer is 256 bytes so this byte variable wraps automatically
+  SerialWiFi._recv_buffer[SerialWiFi._recv_tail]=UDR1; 
+  SerialWiFi._recv_tail++; // buffer is 256 bytes so this byte variable wraps automatically
 }

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -18,9 +18,11 @@
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 #define PSerial Serial
-#define PSerial1 Serial2
+// For STM32F01 MCUs, PA3 is RX2 and PA2 is TX2. These are on Serial2, and should be connected to 
+// an ESP8266's TX and RX respectively
+#define SerialWiFi Serial2
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define HAL_SERIAL_WIFI_ENABLED
 
 // New symbol for the default I2C port -------------------------------------------------------------
 #define HAL_Wire Wire

--- a/src/HAL/HAL_Teensy_3/HAL_Teensy_3.h
+++ b/src/HAL/HAL_Teensy_3/HAL_Teensy_3.h
@@ -14,9 +14,9 @@
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 #define PSerial Serial
-#define PSerial1 Serial1
+#define SerialWiFi Serial1
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define HAL_SERIAL_WIFI_ENABLED
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 #define PSerial4 Serial4
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional

--- a/src/HAL/HAL_Template/HAL_Template.h
+++ b/src/HAL/HAL_Template/HAL_Template.h
@@ -6,7 +6,7 @@
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 #define PSerial Serial
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-//#define PSerial1 Serial1
+//#define SerialWiFi Serial1
 
 // New symbol for the default I2C port -------------------------------------------------------------
 #define HAL_Wire Wire

--- a/src/HAL/HAL_Tiva_C/HAL_Tiva_C.h
+++ b/src/HAL/HAL_Tiva_C/HAL_Tiva_C.h
@@ -55,13 +55,13 @@
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 #if defined(__TM4C123GH6PM__) || defined(__LM4F120H5QR__)
 #define PSerial Serial
-#define PSerial1 Serial1
+#define SerialWiFi Serial1
 #elif defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
 #define PSerial Serial1
-#define PSerial1 Serial7
+#define SerialWiFi Serial7
 #endif
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define HAL_SERIAL_WIFI_ENABLED
 
 // New symbol for the default I2C port -------------------------------------------------------------
 #define HAL_Wire Wire


### PR DESCRIPTION
It was confusing for me to know what PSerial and PSerial1 are. So renamed 1 to WiFi throughout. Still don't know what Serial4 is.