### PR TITLE
Decouple serial port names from their hardware number, get WiFi working on STM32

### DIFF
--- a/Config.Classic.h
+++ b/Config.Classic.h
@@ -21,7 +21,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_B_BAUD_DEFAULT 9600
 
 // Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
 // _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)

--- a/Config.MaxPCB.h
+++ b/Config.MaxPCB.h
@@ -20,8 +20,8 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 and Serial4 com ports, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
-#define SERIAL4_BAUD_DEFAULT 9600
+#define SERIAL_B_BAUD_DEFAULT 9600
+#define SERIAL_C_BAUD_DEFAULT 9600
 
 // ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01
 // Pin 18 (Aux1) for GPIO0 and Pin 5 (Aux2) for Rst control.  Choose only one feature on Aux1/2.

--- a/Config.Mega2560Alt.h
+++ b/Config.Mega2560Alt.h
@@ -17,7 +17,7 @@
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_B_BAUD_DEFAULT 9600
 
 // Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
 // _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)

--- a/Config.MiniPCB.h
+++ b/Config.MiniPCB.h
@@ -20,7 +20,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_B_BAUD_DEFAULT 9600
 
 // ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01
 // Pin 18 (Aux1) for GPIO0 and Pin 5 (Aux2) for Rst control.  Choose only one feature on Aux1/2.

--- a/Config.Ramps14.h
+++ b/Config.Ramps14.h
@@ -26,7 +26,7 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 com port, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
+#define SERIAL_B_BAUD_DEFAULT 9600
 
 // Mount type, default is _GEM (German Equatorial) other options are _FORK, _FORK_ALT.  _FORK switches off Meridian Flips after (1, 2 or 3 star) alignment is done.  _FORK_ALT disables Meridian Flips (1 star align.)
 // _ALTAZM is for Alt/Azm mounted 'scopes (1 star align only.)

--- a/Config.TM4C.h
+++ b/Config.TM4C.h
@@ -22,8 +22,8 @@
 #define ALIGN_GOTOASSIST_OFF
 
 // Default speed for Serial1 and Serial4 com ports, Default=9600
-#define SERIAL1_BAUD_DEFAULT 9600
-#define SERIAL4_BAUD_DEFAULT 9600
+#define SERIAL_B_BAUD_DEFAULT 9600
+#define SERIAL_C_BAUD_DEFAULT 9600
 
 // ESP8266 reset and GPIO0 control, this sets run mode for normal operation.  Uploading programmer firmware to the OpStep MCU can then enable sending new firmware to the ESP8266-01
 // Pin (Aux1) for GPIO0 and Pin (Aux2) for Rst control.  Choose only one feature on Aux1/2.

--- a/Guide.ino
+++ b/Guide.ino
@@ -215,10 +215,10 @@ void ST4() {
         pinMode(ST4DEn,OUTPUT);    // send data
         digitalWrite(ST4DEs,HIGH); // idle
         shcActive=true;
-        PSerialST4.begin();
+        SerialST4.begin();
       }
       return;
-    } else { PSerialST4.poll(); return; }
+    } else { SerialST4.poll(); return; }
   } else {
     if (shcActive) {
       #ifdef ST4_ON
@@ -229,7 +229,7 @@ void ST4() {
         pinMode(ST4DEn,INPUT_PULLUP);
       #endif
       shcActive=false;
-      PSerialST4.end();
+      SerialST4.end();
       return;
     }
   }

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -64,7 +64,7 @@
 #include "src/lib/St4SerialMaster.h"
 
 // Enable debugging messages on DebugSer -------------------------------------------------------------
-#define DEBUG_ON              // default=_OFF, use "DEBUG_ON" to activate
+#define DEBUG_OFF              // default=_OFF, use "DEBUG_ON" to activate
 #define DebugSer SerialA       // default=Serial, or Serial1 for example (always 9600 baud)
 
 // Helper macros for debugging, with less typing

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -63,8 +63,6 @@
 #include "src/HAL/HAL.h"
 #include "src/lib/St4SerialMaster.h"
 
-#define SerialST4 Serial
-
 // Enable debugging messages on DebugSer -------------------------------------------------------------
 #define DEBUG_ON               // default=_OFF, use "DEBUG_ON" to activate
 #define DebugSer SerialST4    // default=Serial, or Serial1 for example (always 9600 baud)

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -63,9 +63,11 @@
 #include "src/HAL/HAL.h"
 #include "src/lib/St4SerialMaster.h"
 
+#define SerialST4 Serial
+
 // Enable debugging messages on DebugSer -------------------------------------------------------------
-#define DEBUG_ON                  // default=_OFF, use "DEBUG_ON" to activate
-#define DebugSer PSerialST4       // default=Serial, or Serial1 for example (always 9600 baud)
+#define DEBUG_ON               // default=_OFF, use "DEBUG_ON" to activate
+#define DebugSer SerialST4    // default=Serial, or Serial1 for example (always 9600 baud)
 
 // Helper macros for debugging, with less typing
 #if defined(DEBUG_ON)
@@ -170,15 +172,15 @@ void setup() {
   // starts the hardware timers that keep sidereal time, move the motors, etc.
   Init_Start_Timers();
 
-  PSerial.begin(9600);
-#ifdef HAL_SERIAL1_ENABLED
-  PSerial1.begin(SERIAL1_BAUD_DEFAULT);
+  Serial.begin(9600);
+#ifdef HAL_SERIAL_B_ENABLED
+  SerialB.begin(SERIAL_B_BAUD_DEFAULT);
 #endif
-#ifdef HAL_SERIAL4_ENABLED
-  PSerial4.begin(SERIAL4_BAUD_DEFAULT);
+#ifdef HAL_SERIAL_C_ENABLED
+  SerialC.begin(SERIAL_C_BAUD_DEFAULT);
 #endif
 #ifdef ST4_HAND_CONTROL_ON
-  PSerialST4.begin();
+  Serial.begin();
 #endif
  
   // autostart tracking

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -64,8 +64,8 @@
 #include "src/lib/St4SerialMaster.h"
 
 // Enable debugging messages on DebugSer -------------------------------------------------------------
-#define DEBUG_ON               // default=_OFF, use "DEBUG_ON" to activate
-#define DebugSer SerialST4    // default=Serial, or Serial1 for example (always 9600 baud)
+#define DEBUG_ON              // default=_OFF, use "DEBUG_ON" to activate
+#define DebugSer SerialA       // default=Serial, or Serial1 for example (always 9600 baud)
 
 // Helper macros for debugging, with less typing
 #if defined(DEBUG_ON)
@@ -128,7 +128,7 @@ void setup() {
 #ifdef DEBUG_ON
   // Initialize USB serial debugging early, so we can use DebugSer.print() for debugging, if needed
   DebugSer.begin(9600);
-  delay(1000);
+  delay(5000);
 #endif
   
   // initialize the Non-Volatile Memory
@@ -145,6 +145,7 @@ void setup() {
 
   // set pins for input/output as specified in Config.h and PinMap.h
   Init_Pins();
+  
   Init_Guide();
 
   // if this is the first startup set EEPROM to defaults
@@ -170,7 +171,7 @@ void setup() {
   // starts the hardware timers that keep sidereal time, move the motors, etc.
   Init_Start_Timers();
 
-  Serial.begin(9600);
+  SerialA.begin(9600);
 #ifdef HAL_SERIAL_B_ENABLED
   SerialB.begin(SERIAL_B_BAUD_DEFAULT);
 #endif
@@ -178,7 +179,7 @@ void setup() {
   SerialC.begin(SERIAL_C_BAUD_DEFAULT);
 #endif
 #ifdef ST4_HAND_CONTROL_ON
-  Serial.begin();
+  SerialST4.begin();
 #endif
  
   // autostart tracking

--- a/Validate.h
+++ b/Validate.h
@@ -204,11 +204,11 @@
 #endif
 
 // set serial port baud rate if not done so already
-#ifndef SERIAL1_BAUD_DEFAULT
-  #define SERIAL1_BAUD_DEFAULT 9600
+#ifndef SERIAL_A_BAUD_DEFAULT
+  #define SERIAL_A_BAUD_DEFAULT 9600
 #endif
-#ifndef SERIAL4_BAUD_DEFAULT
-  #define SERIAL4_BAUD_DEFAULT 9600
+#ifndef SERIAL_B_BAUD_DEFAULT
+  #define SERIAL_B_BAUD_DEFAULT 9600
 #endif
 
 // figure out how many align star are allowed for the configuration

--- a/addons/WiFi-Bluetooth/README.md
+++ b/addons/WiFi-Bluetooth/README.md
@@ -1,43 +1,48 @@
 # OnStep WiFi Server
-
 This is the ESP8266 webserver for OnStep.
 It enables OnStep to be controlled over WiFi (IP). This access can be over a command channel
 and/or website.
 This server is known to work from personal computers (using a browser), phones and tablets,
 (using the Android OnStep App), Sky Safari, and my ASCOM driver (PC.)
 
-# Flashing The WiFi Server
-For an ESP8266 ESP-01 module to be flashed with this firmware, it needs its pins in a certain
-configuration:
+# Installing the ESP8266 Platform
+Before you can flash the firmware on your ESP8266 device, you need to install the ESP8266
+platform for the Arduino IDE.
 
-Pin CH_PD/EN must be HIGH (connected to 3.3V)
-Pin GPIO0 must be LOW (connected to GND).
-
-For the ESP-01 module, you can by adapter boards that help with flashing from eBay, Amazon
-and other sources.
-
-For a WeMos D1 mini or NodeMCU simply plug in via the USB interface.
-To send the firmware I use the Arduino IDE with the add-on for the ESP8266, as follows:
-
-Under Preferences add this line in the additional "Boards Manager" area:
+nder Preferences add this line in the additional "Boards Manager" area:
 http://arduino.esp8266.com/stable/package_esp8266com_index.json
 
 Then from the "Tools, Boards, Boards Manager" menu select and install the ESP8266 add-on.
 
-Then pick "Tools, Boards, Generic 8266 Module" (for an ESP-01) or select your device from the list.
+# Flashing The WiFi Server
+Then pick your device from "Tools, Boards". 
 
-If you are using an ESP-01, then use the following parameters under Tools:
+For a WeMos D1 Mini or NodeMCU, select the device from the list.
+For an ESP-01, select "Generic 8266 Module" (for an ESP-01)
+
+For devices with a USB port, you can connect directly using the USB connector.
+
+The exact flashing procedure depends on which ESP8826 device you will be using.
+
+For an ESP-01 module, its pins should be in a certain configuration:
+
+Pin CHPD/EN must be HIGH (connected to 3.3V)
+Pin GPIO0 must be LOW (connected to GND).
+
+You can by adapter boards that help with flashing from eBay, Amazon and other sources.
+
+For the ESP-01, use the following parameters under Tools:
 
 - Flash Mode: “DIO”
 - Flash Frequency: “40MHz”
 - CPU Frequency: “80 MHz”
-- Flash Size: “512K (64K SPIFFS)”
+- Flash Size: “1M (64K SPIFFS)”
 - Reset Method: “ck”
 - Upload Speed: “115200”
 - Debug Port: “Disabled”
 - Debug Level: “None”
 
-This source code is inside your OnStep folder under the "addons/WiFi-Bluetooth" subdirectory.
+The source code is inside your OnStep folder under the "addons/WiFi-Bluetooth" subdirectory.
 
 Open the WiFi-Bluetooth.ino file inside this folder. Check the "Config.h" file for information
 about serial port wiring and to configure before uploading.  Once this is done upload to the ESP8266.

--- a/src/HAL/HAL_Due/HAL_Due.h
+++ b/src/HAL/HAL_Due/HAL_Due.h
@@ -7,10 +7,10 @@
 #define MaxRate_LowerLimit 16
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
-#define PSerial Serial
-#define PSerial1 Serial1
-// SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define SerialA Serial
+#define SerialB Serial1
+// SERIAL is always enabled SERIAL_A and SERIAL4 are optional
+#define HAL_SERIAL_B_ENABLED
 
 // New symbol for the default I2C port ---------------------------------------------------------------
 #define HAL_Wire Wire

--- a/src/HAL/HAL_Mega2560/HAL_Mega2560.h
+++ b/src/HAL/HAL_Mega2560/HAL_Mega2560.h
@@ -13,8 +13,8 @@
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 // Use low overhead serial
 #include "HAL_Serial.h"
-// SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+// SERIAL is always enabled SERIAL_A and SERIAL4 are optional
+#define HAL_SERIAL_B_ENABLED
 // this tells OnStep that a .transmit() method needs to be called to send data
 #define HAL_SERIAL_TRANSMIT
 

--- a/src/HAL/HAL_Mega2560/HAL_Serial.h
+++ b/src/HAL/HAL_Mega2560/HAL_Serial.h
@@ -174,17 +174,17 @@ class pserial1 {
     byte _xmit_index         = 0;
 };
 
-pserial PSerial;
-pserial1 PSerial1;
+pserial SerialA;
+pserial1 SerialB;
 
 // UART Receive Complete Interrupt Handler for Serial0
 ISR(USART0_RX_vect)  {
-  PSerial._recv_buffer[PSerial._recv_tail]=UDR0; 
-  PSerial._recv_tail++; // buffer is 256 bytes so this byte variable wraps automatically
+  SerialA._recv_buffer[SerialA._recv_tail]=UDR0; 
+  SerialA._recv_tail++; // buffer is 256 bytes so this byte variable wraps automatically
 }
 
 // UART Receive Complete Interrupt Handler for Serial1
 ISR(USART1_RX_vect)  {
-  PSerial1._recv_buffer[PSerial1._recv_tail]=UDR1; 
-  PSerial1._recv_tail++; // buffer is 256 bytes so this byte variable wraps automatically
+  SerialB._recv_buffer[SerialB._recv_tail]=UDR1; 
+  SerialB._recv_tail++; // buffer is 256 bytes so this byte variable wraps automatically
 }

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -37,7 +37,7 @@
 //   Serial  -> USART 1
 //   Serial1 -> USART 2
 //   Serial2 -> USART 3
-#define SerialB Serial2
+#define SerialB Serial3
 
 // SERIAL is always enabled SERIAL_A and SERIAL4 are optional
 #define HAL_SERIAL_B_ENABLED

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -17,10 +17,10 @@
 #define sei() interrupts()
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
-#define PSerial Serial
-#define PSerial1 Serial2
-// SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define SerialA Serial
+#define SerialB Serial2
+// SERIAL is always enabled SERIAL_A and SERIAL4 are optional
+#define HAL_SERIAL_B_ENABLED
 
 // New symbol for the default I2C port -------------------------------------------------------------
 #define HAL_Wire Wire

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -22,24 +22,27 @@
 // Which port to use for WiFi?
 //
 // The hardware serial ports and pins for STM32F103 are:
-//   USART1: TX PA9, RX PA10
-//   USART2: TX PA2, RX PA3
+//   USART1: TX PA9,  RX PA10
+//   USART2: TX PA2,  RX PA3
 //   USART3: TX PB10, RX PB11
 
-// Note that different flashing methods will remap the port numbers.
-// For DFU (STM32Duino), and ST-Link, ports are:
+// Different flashing methods will remap the port numbers differently, as follows.
+//
+// For DFU (STM32duino), or ST-Link V2, the ports are:
 //   Serial1 -> USART 1
 //   Serial2 -> USART 2
 //   Serial3 -> USART 3
-
-// If you use a USB to TTL dongle, the flashing method is Serial, and
-// the ports are:
+// If "Serial" method, using a USB to TTL dongle on pins A9 and A10, the ports are:
 //   Serial  -> USART 1
 //   Serial1 -> USART 2
 //   Serial2 -> USART 3
-#define SerialB Serial3
+#if defined(SERIAL_USB)
+  #define SerialB Serial3
+#else
+  #define SerialB Serial2
+#endif
 
-// SERIAL is always enabled SERIAL_A and SERIAL4 are optional
+// Serial is always enabled (USB), SERIAL_B and SERIAL_C are optional
 #define HAL_SERIAL_B_ENABLED
 
 // New symbol for the default I2C port -------------------------------------------------------------

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -18,7 +18,27 @@
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 #define SerialA Serial
+
+// Which port to use for WiFi?
+//
+// The hardware serial ports and pins for STM32F103 are:
+//   USART1: TX PA9, RX PA10
+//   USART2: TX PA2, RX PA3
+//   USART3: TX PB10, RX PB11
+
+// Note that different flashing methods will remap the port numbers.
+// For DFU (STM32Duino), and ST-Link, ports are:
+//   Serial1 -> USART 1
+//   Serial2 -> USART 2
+//   Serial3 -> USART 3
+
+// If you use a USB to TTL dongle, the flashing method is Serial, and
+// the ports are:
+//   Serial  -> USART 1
+//   Serial1 -> USART 2
+//   Serial2 -> USART 3
 #define SerialB Serial2
+
 // SERIAL is always enabled SERIAL_A and SERIAL4 are optional
 #define HAL_SERIAL_B_ENABLED
 

--- a/src/HAL/HAL_Teensy_3/HAL_Teensy_3.h
+++ b/src/HAL/HAL_Teensy_3/HAL_Teensy_3.h
@@ -13,14 +13,14 @@
 #endif
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
-#define PSerial Serial
-#define PSerial1 Serial1
-// SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+#define SerialA Serial
+#define SerialB Serial1
+// SERIAL is always enabled SERIAL_B and SERIAL4 are optional
+#define HAL_SERIAL_B_ENABLED
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-#define PSerial4 Serial4
-// SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL4_ENABLED
+#define SerialC Serial4
+// SERIAL is always enabled SERIAL_B and SERIAL4 are optional
+#define HAL_SERIAL_C_ENABLED
 #endif
 
 // New symbol for the default I2C port -------------------------------------------------------------

--- a/src/HAL/HAL_Template/HAL_Template.h
+++ b/src/HAL/HAL_Template/HAL_Template.h
@@ -4,9 +4,9 @@
 #define __Platform_Name__
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
-#define PSerial Serial
+#define SerialA Serial
 // SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-//#define PSerial1 Serial1
+#define SerialB Serial1
 
 // New symbol for the default I2C port -------------------------------------------------------------
 #define HAL_Wire Wire

--- a/src/HAL/HAL_Tiva_C/HAL_Tiva_C.h
+++ b/src/HAL/HAL_Tiva_C/HAL_Tiva_C.h
@@ -54,14 +54,14 @@
 
 // New symbols for the Serial ports so they can be remapped if necessary -----------------------------
 #if defined(__TM4C123GH6PM__) || defined(__LM4F120H5QR__)
-#define PSerial Serial
-#define PSerial1 Serial1
+#define SerialA Serial
+#define SerialB Serial1
 #elif defined(__TM4C1294NCPDT__) || defined(__TM4C1294XNCZAD__)
-#define PSerial Serial1
-#define PSerial1 Serial7
+#define SerialA Serial1
+#define SerialB Serial7
 #endif
-// SERIAL is always enabled SERIAL1 and SERIAL4 are optional
-#define HAL_SERIAL1_ENABLED
+// SerialA is always enabled, SerialB and SerialC are optional
+#define HAL_SERIAL_B_ENABLED
 
 // New symbol for the default I2C port -------------------------------------------------------------
 #define HAL_Wire Wire

--- a/src/lib/St4SerialMaster.h
+++ b/src/lib/St4SerialMaster.h
@@ -201,5 +201,5 @@ void Mst4::flush(void) {
   } while ((c!=0) || ((millis()-startMs)<_timeout));
 }
 
-Mst4 PSerialST4;
+Mst4 SerialST4;
 

--- a/src/pinmaps/Pins.STM32Black.h
+++ b/src/pinmaps/Pins.STM32Black.h
@@ -77,7 +77,7 @@
 
 // The PPS pin is a 3.3V logic input, OnStep measures time between rising edges and
 // adjusts the internal sidereal clock frequency
-//#define PpsPin       Undefined    // Pulse Per Second time source, e.g. GPS
+#define PpsPin         PA12         // Pulse Per Second time source, e.g. GPS
 
 #else
 #error "Wrong processor for this configuration!"

--- a/src/pinmaps/Pins.STM32Black.h
+++ b/src/pinmaps/Pins.STM32Black.h
@@ -77,7 +77,7 @@
 
 // The PPS pin is a 3.3V logic input, OnStep measures time between rising edges and
 // adjusts the internal sidereal clock frequency
-#define PpsPin         PA12         // Pulse Per Second time source, e.g. GPS
+#define PpsPin         PA13         // Pulse Per Second time source, e.g. GPS
 
 #else
 #error "Wrong processor for this configuration!"

--- a/src/pinmaps/Pins.STM32CZ.h
+++ b/src/pinmaps/Pins.STM32CZ.h
@@ -77,7 +77,7 @@
 
 // The PPS pin is a 3.3V logic input, OnStep measures time between rising edges and
 // adjusts the internal sidereal clock frequency
-//#define PpsPin       Undefined    // Pulse Per Second time source, e.g. GPS
+#define PpsPin         PA12         // Pulse Per Second time source, e.g. GPS
 
 #else
 #error "Wrong processor for this configuration!"


### PR DESCRIPTION
Use A, B, C for serial ports. B and C can be assigned to Serial1, Serial4, Serial7, ...etc. depending on the platform. 

No confusion for those checking HAL or OnStep's source code. 