### PR TITLE
Support for the Blue Pill STM32 board.

### DIFF
--- a/Config.STM32.h
+++ b/Config.STM32.h
@@ -1,21 +1,20 @@
 // -----------------------------------------------------------------------------------
 // Configuration for OnStep STM32
 
-/*
- * For more information on setting OnStep up see http://www.stellarjourney.com/index.php?r=site/equipment_onstep and 
- * join the OnStep Groups.io at https://groups.io/g/onstep
- * 
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * * * * *
- * See the appropriate file below for detailed information on this pin map to be sure it matches your wiring *** USE AT YOUR OWN RISK ***
- * ~/OnStep/src/pinmaps/Pins.STM32Black.h                                                                                               *  
- * ~/OnStep/src/pinmaps/Pins.STM32CZ.h                                                                                                  *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * * * * *
-*/
+// For more information on setting OnStep up see:
+//   http://www.stellarjourney.com/index.php?r=site/equipment_onstep and 
+// Join the OnStep Groups.io, and view the Wiki at: https://groups.io/g/onstep
+//
+// See the appropriate file below for detailed information on this pin map to be
+// sure it matches your wiring
+//
+// *** USE AT YOUR OWN RISK ***
 
-#define STM32Black_OFF   //  <- Turn _ON to use STM32F103C8T6 Black with this configuration OR
-#define STM32CZ_OFF      //  <- Turn _ON to use STM32F103VET6 CZ with this configuration
+#define STM32Blue_OFF    //  <- Turn _ON to use STM32F103C8T6 Blue Pill, or
+#define STM32Black_OFF   //  <- Turn _ON to use STM32F103C8T6 Black Pill, or
+#define STM32CZ_OFF      //  <- Turn _ON to use STM32F103VET6 CZ Mini
 
-#if defined(STM32Black_ON) || defined(STM32CZ_ON)
+#if defined(STM32Black_ON) || defined(STM32Blue_ON) || defined(STM32CZ_ON)
 // -------------------------------------------------------------------------------------------------------------------------
 // ADJUST THE FOLLOWING TO CONFIGURE YOUR CONTROLLER FEATURES --------------------------------------------------------------
 
@@ -212,10 +211,12 @@
 
 // -------------------------------------------------------------------------------------------------------------------------
 #define FileVersionConfig 2
-#if defined(STM32Black_ON)
-  #include "src/pinmaps/Pins.STM32Black.h"
+
+#if defined(STM32Black_ON) || defined(STM32Blue_ON)
+  #include "src/pinmaps/Pins.STM32B.h"
 #elif defined(STM32CZ_ON)
   #include "src/pinmaps/Pins.STM32CZ.h"
 #endif
+
 #endif
 

--- a/Validate.h
+++ b/Validate.h
@@ -55,7 +55,13 @@
     #define Configuration_Found
   #endif
 #endif
-
+#ifdef STM32Blue_ON
+  #ifdef Configuration_Found
+    #define Configuration_Duplicate
+  #else
+    #define Configuration_Found
+  #endif
+#endif
 #ifdef Configuration_Duplicate
   #error "You have more than one Config.xxx.h file enabled, ONLY ONE can be enabled with _ON."
 #endif

--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -1,12 +1,18 @@
 // -------------------------------------------------------------------------------------------------
 // Pin map for OnStep on STM32
 // 
-// This pin map is for an STM32F103C8T6 "Black Pill" stick.
-// It runs at 72MHz has 128K flash and 20K RAM, and is 3.3V only
+// This pin map is for an STM32F103C8T6 "Black Pill" and "Blue Pill" sticks.
+// They run at 72MHz, have 128K flash and 20K RAM
+// The Black variant is 3.3V only, while the Blue has some pins that are 5V tolerant.
+// The Black Pill has two less pins than the Blue Pill. The Blue Pill has two flaws
+// with workarounds, wrong resistor interfers with flashing via USB, and a flimsy
+// USB connector. 
 //
-// Cost on eBay and AliExpress is less than US $2.50
 // More info, schematic at:
 //   http://wiki.stm32duino.com/index.php?title=Black_Pill
+//   http://wiki.stm32duino.com/index.php?title=Blue_Pill
+//
+// Cost on eBay and AliExpress is less than US $2.50
 //
 // Other boards based on the following chips also have enough flash
 // and RAM for OnStep, and should work, with pin modifications.
@@ -47,7 +53,13 @@
 
 // This is the built in LED for the Black Pill board. There is a pin
 // available from it too, in case you want to power another LED with a wire
-#define LEDnegPin       PB12         // Drain
+#if defined(STM32Black_ON)
+  #define LEDnegPin     PB12   // Drain
+#elif defined(STM32Blue_ON) 
+  #define LEDnegPin     PC13   // Drain
+#else
+  #error "Unknown STM32 Board. Can't assign an LED Pin"
+#endif
 
 // For a piezo buzzer
 #define TonePin         PB4    // Tone


### PR DESCRIPTION
The Blue Pill is the predecessor of the Black Pill. It has 2 more pins, and some pins are 5V tolerant. 

Support is added via the same pinmap file.