### PR TITLE
Modifications to STM32 pinmap, since hardware SPI pins not required

### DIFF
--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -48,18 +48,20 @@
   #define A1M2          PA0  
   #define A1ST          PC13
   #define A1DR          PB9
+  #define A1MO          PB8
 
-  #define A2EN          PB13
-  #define A2M0          PB14
-  #define A2M1          PB15
+  #define A2EN          PA15
+  #define A2M0          PA10
+  #define A2M1          PA9 
   #define A2M2          PA8 
-  #define A2ST          PA9
-  #define A2DR          PA10
+  #define A2ST          PB15
+  #define A2DR          PB14
+  #define A2MO          PB13
 
-  #define S4N           PA13
-  #define S4S           PA14
-  #define S4W           PA15
-  #define S4E           PB3
+  #define S4N           PA7 
+  #define S4S           PA6 
+  #define S4W           PA5 
+  #define S4E           PA4 
 
   #define LED           PB12
   #define TONE          PB4 
@@ -68,23 +70,27 @@
   #define F1DR          PB0 
   #define F1ST          PB1 
 
-  #define SPARE1        PB8
+  #define SPARE1        PB3
+  #define SPARE2        PA13
+  #define SPARE3        PA14
 
 #elif defined(STM32Blue_ON) 
 
-  #define A1EN          PA9 
-  #define A1M0          PA8 
-  #define A1M1          PB15
-  #define A1M2          PB14
-  #define A1ST          PB13
-  #define A1DR          PB12
+  #define A1EN          PA10
+  #define A1M0          PA9 
+  #define A1M1          PA8 
+  #define A1M2          PB15
+  #define A1ST          PB14
+  #define A1DR          PB13
+  #define A1MO          PB12
 
-  #define A2EN          PC14
-  #define A2M0          PC15
-  #define A2M1          PA0
+  #define A2EN          PA4  
+  #define A2M0          PA3 
+  #define A2M1          PA2
   #define A2M2          PA1 
-  #define A2ST          PA2 
-  #define A2DR          PA3 
+  #define A2ST          PA0 
+  #define A2DR          PC15
+  #define A2MO          PC14
 
   #define S4N           PA15
   #define S4S           PB3 
@@ -114,8 +120,8 @@
 #define Axis1_M2        A1M2   // Microstep Mode 2
 #define Axis1StepPin    A1ST   // Step
 #define Axis1DirPin     A1DR   // Motor Direction
+#define Axis1_Aux       A1MO   // Aux - ESP8266 GPIO0 or SPI MISO
 //#define Axis1_FAULT   Undefined    // Fault
-//#define Axis1_Aux     Axis1_Aux    // Aux - ESP8266 GPIO0 or SPI MISO
 
 #define Axis2_EN        A2EN   // Enable
 #define Axis2_M0        A2M0   // Microstep Mode 0
@@ -123,8 +129,8 @@
 #define Axis2_M2        A2M2   // Microstep Mode 2
 #define Axis2StepPin    A2ST   // Step
 #define Axis2DirPin     A2DR   // Motor Direction
+#define Axis2_Aux       A2MO   // Aux - ESP8266 RST or SPI MISO
 //#define Axis2_FAULT   Undefined    // Fault
-//#define Axis2_Aux     Axis2_FAULT  // Aux - ESP8266 RST or SPI MISO
 
 // ST4 interface
 #define ST4DEn          S4N    // ST4 DE+ North

--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -69,10 +69,10 @@
 
   #define F1DR          PB0 
   #define F1ST          PB1 
+  #define F1EN          PB3
 
-  #define SPARE1        PB3
-  #define SPARE2        PA13
-  #define SPARE3        PA14
+  #define SPARE1        PA13
+  #define SPARE2        PA14
 
 #elif defined(STM32Blue_ON) 
 
@@ -101,14 +101,14 @@
   #define TONE          PB9 
   #define SQW           PB8 
 
-  #define F1DR          PB0 
-  #define F1ST          PB1
+  #define F1DR          PA5 
+  #define F1ST          PA6 
+  #define F1EN          PA7 
 
-  #define SPARE1        PA5 
-  #define SPARE2        PA6 
-  #define SPARE3        PA7 
-  #define SPARE4        PA13
-  #define SPARE5        PA14
+  #define SPARE1        PA13
+  #define SPARE2        PA14
+  #define SPARE3        PB0 
+  #define SPARE4        PB1
 
 #else
   #error "Unknown STM32 Board. This pinmap is only for Blue and Black Pill variants"
@@ -154,14 +154,15 @@
 // Pins to focuser1 stepper driver
 #define Axis4DirPin     F1DR   // Dir
 #define Axis4StepPin    F1ST   // Step
-
-// For rotator stepper driver
-//#define Axis3DirPin     PB4    // Dir
-//#define Axis3StepPin    PB5    // Step
+#define Axis4_EN        F1EN   // Step
 
 // For focuser2 stepper driver
-//#define Axis5DirPin   Undefined    // Dir
-//#define Axis5StepPin  Undefined    // Step
+//#define Axis5DirPin     F2DR   // Dir
+//#define Axis5StepPin    F2ST   // Step
+
+// For rotator stepper driver
+//#define Axis5DirPin   PB4    // Dir
+//#define Axis5StepPin  PB5    // Step
 
 // The limit switch sense is a logic level input which uses the internal pull up,
 // shorted to ground it stops gotos/tracking
@@ -169,8 +170,8 @@
 
 // The PEC index sense is a logic level input, resets the PEC index on rising
 // edge then waits for 60 seconds before allowing another reset
-//#define PecPin       Undefined
-//#define AnalogPecPin Undefined    // PEC Sense, analog or digital
+//#define PecPin        Undefined
+//#define AnalogPecPin  Undefined    // PEC Sense, analog or digital
 
 //#define LEDneg2Pin    Undefined    // Drain
 

--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -104,9 +104,11 @@
   #define F1DR          PB0 
   #define F1ST          PB1
 
-  #define SPARE1        PA10
-  #define SPARE2        PA13
-  #define SPARE3        PA14
+  #define SPARE1        PA5 
+  #define SPARE2        PA6 
+  #define SPARE3        PA7 
+  #define SPARE4        PA13
+  #define SPARE5        PA14
 
 #else
   #error "Unknown STM32 Board. This pinmap is only for Blue and Black Pill variants"


### PR DESCRIPTION
Since the hardware SPI pins are not needed for the TMC2130 (it uses SoftSPI), we have a few spare pins, and can re-purpose the SPI ones.

Also, a focuser needs three pins (Enable, Step and Dir), not just the latter two. 

Reworked the pinmap to account for all the above. 