### PR TITLE
New HAL_init() function, to allow platform specific initialization

### DIFF
--- a/OnStep.ino
+++ b/OnStep.ino
@@ -133,6 +133,9 @@ void setup() {
   delay(5000);
 #endif
   
+  // Call hardware specific initialization
+  HAL_Init();
+
   // initialize the Non-Volatile Memory
   nv.init();
 

--- a/src/HAL/HAL_Due/HAL_Due.h
+++ b/src/HAL/HAL_Due/HAL_Due.h
@@ -50,6 +50,9 @@ void TIMER4_COMPA_vect(void);
 extern long int siderealInterval;
 extern void SiderealClockSetInterval (long int);
 
+void HAL_Init(void) {
+}
+
 // Init sidereal clock timer
 void HAL_Init_Timer_Sidereal() {
   Timer5.attachInterrupt(TIMER1_COMPA_vect);

--- a/src/HAL/HAL_Mega2560/HAL_Mega2560.h
+++ b/src/HAL/HAL_Mega2560/HAL_Mega2560.h
@@ -58,6 +58,9 @@
 extern long int siderealInterval;
 extern void SiderealClockSetInterval (long int);
 
+void HAL_Init(void) {
+}
+
 // Init sidereal clock timer
 void HAL_Init_Timer_Sidereal() {
   SiderealClockSetInterval(siderealInterval);

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -70,6 +70,11 @@
 // frequency compensation (F_COMP/1000000.0) for adjusting microseconds to timer counts
 #define F_COMP 1000000.0
 
+void HAL_Init(void) {
+  // Make sure that debug pins are not reserved, and therefore usable as GPIO
+  disableDebugPorts();
+}
+
 // initialised here and not in timer.ino
 void TIMER1_COMPA_vect(void);
 

--- a/src/HAL/HAL_Teensy_3/HAL_Teensy_3.h
+++ b/src/HAL/HAL_Teensy_3/HAL_Teensy_3.h
@@ -48,6 +48,9 @@
 // frequency compensation (F_COMP/1000000.0) for adjusting microseconds to timer counts
 #define F_COMP F_BUS
 
+void HAL_Init(void) {
+}
+
 IntervalTimer itimer3;
 void TIMER3_COMPA_vect(void);
 

--- a/src/HAL/HAL_Template/HAL_Template.h
+++ b/src/HAL/HAL_Template/HAL_Template.h
@@ -29,6 +29,9 @@
 // frequency compensation (F_COMP/1000000.0) for adjusting microseconds to timer counts
 #define F_COMP 1000000
 
+void HAL_Init(void) {
+}
+
 #define ISR(f) void f (void)
 void TIMER1_COMPA_vect(void);  // Sidereal timer
 void TIMER3_COMPA_vect(void);  // Axis1 RA/Azm timer

--- a/src/HAL/HAL_Tiva_C/HAL_Tiva_C.h
+++ b/src/HAL/HAL_Tiva_C/HAL_Tiva_C.h
@@ -77,6 +77,9 @@
   uint32_t g_ui32SysClock = SysCtlClockFreqSet((SYSCTL_XTAL_25MHZ | SYSCTL_OSC_MAIN | SYSCTL_USE_PLL | SYSCTL_CFG_VCO_480), F_BUS);
 #endif
 
+void HAL_Init(void) {
+}
+
 // The Energia IDE does not have IntervalTimer so we have to initialise timers manually
 
 // We initialize these here and not in timer.ino


### PR DESCRIPTION
On the STM32, we need a call to a platform specific function that disables the reservation of certain pins for debugging. This means that the pins are reclaimed and reusable again. 

Implemented in a way that allows any platform to have init functions that are specific to it, in the HAL_platform.h file. 