### PR TITLE
Validation of PECBufferSize

### DIFF
--- a/Validate.h
+++ b/Validate.h
@@ -535,4 +535,6 @@
   #warning "Configuration: the MaxRate run-time adjustability (0.5x to 2x MaxRate) can be set to exceed the platform performance, you might want to increase MaxRate or use/adjust micro-step mode switching"
 #endif
 
-
+#if PECBufferSize > 3384
+  #error "PECBufferSize cannot be greater than 3384. Please use the spreadsheet to calculate your correct value"
+#endif

--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -77,7 +77,7 @@
   #define A1ST          PB9
   #define A1DR          PB8
 
-  #define A2EN          PB3 
+  #define A2EN          PA15
   #define A2M0          PA12
   #define A2M1          PA11 
   #define A2M2          PA8  
@@ -96,10 +96,10 @@
 
   #define PECIDX        PB0
 
-  #define SPARE1        PA15
-  #define SPARE2        PA14
-  #define SPARE3        PA13
-  #define SPARE4        PB4
+  #define SPARE1        PB3 
+  #define SPARE2        PB4
+  #define SPARE3        PA14
+  #define SPARE4        PA13
 
 #else
   #error "Unknown STM32 Board. This pinmap is only for Blue and Black Pill variants"


### PR DESCRIPTION
This prevents errors resulting from putting in an insanely large value, and points the user to use the spreadsheet to get the correct value.