### PR TITLE
Allow alignment from plate solving

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -1991,11 +1991,11 @@ bool cmdReply(char *s) {
 
 boolean AlignStar() {
   // after last star turn meridian flips off when align is done
-  if ((alignNumStars==alignThisStar) && (meridianFlip==MeridianFlipAlign)) {
+  if ((alignNumStars == alignThisStar) && (meridianFlip == MeridianFlipAlign)) {
     meridianFlip=MeridianFlipNever;
   }
           
-  if (alignThisStar<=alignNumStars) {
+  if (alignThisStar <= alignNumStars) {
     // AltAz or Equ mode
     if (Align.addStar(alignThisStar,alignNumStars,newTargetRA,newTargetDec)) {
       alignThisStar++;

--- a/Command.ino
+++ b/Command.ino
@@ -158,10 +158,7 @@ void processCommands() {
           } else commandError=true;
 #endif
 
-          if (commandError) {
-            alignNumStars=0;
-            alignThisStar=1;
-          }
+          if (commandError) { alignNumStars=0; alignThisStar=1; }
         } else
 //  :A+#  Manual Alignment, set target location
 //         Returns:
@@ -175,10 +172,10 @@ void processCommands() {
           }
         }
         else
-          commandError=true; 
+          commandError=true;
       }
       else
-      
+
 //   $ - Set parameter
 //  :$BDddd# Set Dec/Alt Antibacklash
 //          Return: 0 on failure
@@ -255,11 +252,7 @@ void processCommands() {
               commandError = AlignStar();
               strcpy(reply,"N/A");
             }
-            if (i>0 || commandError) {
-              reply[0]='E';
-              reply[1]='0'+i;
-              reply[2]=0;
-            }
+            if (i>0) { reply[0]='E'; reply[1]='0'+i; reply[2]=0; }
           }
           quietReply=true;
         }

--- a/Command.ino
+++ b/Command.ino
@@ -158,24 +158,26 @@ void processCommands() {
           } else commandError=true;
 #endif
 
-          if (commandError) { alignNumStars=0; alignThisStar=1; }
+          if (commandError) {
+            alignNumStars=0;
+            alignThisStar=1;
+          }
         } else
 //  :A+#  Manual Alignment, set target location
 //         Returns:
 //         1: If correction is accepted
 //         0: Failure, Manual align mode not set or distance too far 
         if (command[1]=='+') {
-            // after last star turn meridian flips off when align is done
-            if ((alignNumStars==alignThisStar) && (meridianFlip==MeridianFlipAlign)) meridianFlip=MeridianFlipNever;
-          
-            if (alignThisStar<=alignNumStars) {
-              // AltAz or Equ mode
-              if (Align.addStar(alignThisStar,alignNumStars,newTargetRA,newTargetDec)) alignThisStar++; else commandError=true;
-            } else commandError=true;
-
-          if (commandError) { alignNumStars=0; alignThisStar=0; }
-        } else commandError=true; 
-      } else
+          commandError = AlignStar();
+          if (commandError) {
+            alignNumStars=0;
+            alignThisStar=0;
+          }
+        }
+        else
+          commandError=true; 
+      }
+      else
       
 //   $ - Set parameter
 //  :$BDddd# Set Dec/Alt Antibacklash
@@ -249,8 +251,15 @@ void processCommands() {
         if ((parkStatus==NotParked) && (trackingState!=TrackingMoveTo)) {
           i=syncEqu(newTargetRA,newTargetDec);
           if (command[1]=='M') {
-            if (i==0) strcpy(reply,"N/A");
-            if (i>0) { reply[0]='E'; reply[1]='0'+i; reply[2]=0; }
+            if (i==0) {
+              commandError = AlignStar();
+              strcpy(reply,"N/A");
+            }
+            if (i>0 || commandError) {
+              reply[0]='E';
+              reply[1]='0'+i;
+              reply[2]=0;
+            }
           }
           quietReply=true;
         }
@@ -1987,3 +1996,25 @@ bool cmdReply(char *s) {
   return true;
 }
 
+boolean AlignStar() {
+  // after last star turn meridian flips off when align is done
+  if ((alignNumStars==alignThisStar) && (meridianFlip==MeridianFlipAlign)) {
+    meridianFlip=MeridianFlipNever;
+  }
+          
+  if (alignThisStar<=alignNumStars) {
+    // AltAz or Equ mode
+    if (Align.addStar(alignThisStar,alignNumStars,newTargetRA,newTargetDec)) {
+      alignThisStar++;
+    }
+    else {
+      return true;
+    }
+  }
+  else {
+    return true;
+  }
+
+  // All good
+  return false;
+}


### PR DESCRIPTION
This adds Alignment using Plate Solving to OnStep. For example, it allows the use of Mount Model tool in KStars/Ekos.

The work flow is to start an Align in OnStep with N stars (e.g. from the INDI control panel), then use the Mount Model with that same exact number of stars, and let Ekos turn the mount around the sky and take images, plate solve them, and sync on the coordinates. 

When a sync is done (i.e. :CM# command) and OnStep detects that the alignment is in progress (i.e. number of stars aligned is not the same as number of stars selected), OnStep internally calls the AddStar align, mimicking an explicit :A+# command.
 
No error checking yet. 

This is tested indoors, but still untested under the stars, please test if you can. 
