### PR TITLE
Moving TONE and RETICLE to pins that have higher current

### DIFF
--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -56,10 +56,10 @@
   #define S4E           PB1
 
   #define LED           PC13
-  #define TONE          PC14
 
-  #define RETICLE       PB9 
-  #define PECIDX        PB8
+  #define TONE          PB9 
+  #define RETICLE       PB8
+  #define PECIDX        PC14
 
   #define SQW           PB5 
 


### PR DESCRIPTION
TONE and RETICLE are now on higher current pin, and PECIDX is on the low current pin.