### PR TITLE
Fix Tracking on STM32

### DIFF
--- a/Timer.ino
+++ b/Timer.ino
@@ -419,10 +419,11 @@ void autoPowerDownAxis2() {
 #if defined(PPS_SENSE_ON) || defined(PPS_SENSE_PULLUP)
 // PPS interrupt
 void clockSync() {
+  #define NUM_SECS_TO_AVERAGE 40
   unsigned long t=micros();
   unsigned long oneS=(t-PPSlastMicroS);
   if ((oneS>1000000-20000) && (oneS<1000000+20000)) {
-    PPSavgMicroS=(PPSavgMicroS*19+oneS)/20;
+    PPSavgMicroS=(PPSavgMicroS*(NUM_SECS_TO_AVERAGE-1)+oneS)/NUM_SECS_TO_AVERAGE;
     PPSsynced=true;
   } else PPSsynced=false;
   PPSlastMicroS=t;

--- a/Timer.ino
+++ b/Timer.ino
@@ -73,7 +73,7 @@ void timer4SetInterval(long iv) {
   uint32_t i=iv; uint16_t t=1; while (iv>65536L) { t*=2; iv=i/t; if (t==4096) { iv=65535L; break; } }
   cli(); nextAxis2Rate=iv-1L; t4rep=t; fastAxis2=(t4rep==1); sei();
 #elif defined(__ARM_STM32__)
-  uint32_t i=iv; uint16_t t=1; while (iv>65536L*2L) { t++; iv=i/t; if (t==32) { iv=65535L*32L; break; } }
+  uint32_t i=iv; uint16_t t=1; while (iv>65536L*2L) { t++; iv=i/t; if (t==32) { iv=65535L*2L; break; } }
   cli(); nextAxis2Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t4rep=t; fastAxis2=(t4rep==1); sei();
 #else
   // 4.194 * 32 = 134.21s


### PR DESCRIPTION
Tracking in RA is now fixed.

The time for averaging the results from second ticks on PPS is increased from 20 to 40, and makes a big difference. 