### PR TITLE
Added :GXFE# command to display angle for both axes.

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -742,6 +742,7 @@ void processCommands() {
               case '9': cli(); temp=(long)(posAxis2); sei(); sprintf(reply,"%ld",temp); quietReply=true; break;                            // Debug9, Dec motor position
               case 'A': sprintf(reply,"%ld%%",(worst_loop_time*100L)/9970L); worst_loop_time=0; quietReply=true; break;                    // DebugA, Workload
               case 'B': cli(); temp=(long)(trackingTimerRateAxis1*1000.0); sei(); sprintf(reply,"%ld",temp); quietReply=true; break;       // DebugB, trackingTimerRateAxis1
+              case 'E': double ra, de; cli(); getEqu(&ra,&de,false); sei(); sprintf(reply,"%f,%f",ra,de); quietReply=true; break;          // DebugE, equatorial coordinates degrees (no division by 15)
               default:  commandError=true;
             }
           } else


### PR DESCRIPTION
A simple command to retrieve the raw angles for both axes. 

No conversion of degrees to RA, so easier to calculate the exact arc second.

It is very useful in scripting tests that monitor drift. 

Example:

:GR#:GD#:GXFE# produces:

2018-11-15 15:08:22 23:04:46#+15*12:18# 346.190611,15.205035#
2018-11-15 15:10:23 23:04:46#+15*12:18# 346.190396,15.205035#
2018-11-15 15:12:23 23:04:46#+15*12:18# 346.190222,15.205035#
2018-11-15 15:14:23 23:04:46#+15*12:18# 346.190007,15.205035#
2018-11-15 15:16:23 23:04:46#+15*12:18# 346.189792,15.205035#
2018-11-15 15:18:23 23:04:46#+15*12:18# 346.189590,15.205035#
2018-11-15 15:20:24 23:04:45#+15*12:18# 346.189382,15.205035#
2018-11-15 15:22:24 23:04:45#+15*12:18# 346.189153,15.205035#
2018-11-15 15:24:24 23:04:45#+15*12:18# 346.188972,15.205035#

So: ((346.190611-346.188972) = degrees drift for duration
Divide by duration of test in minutes (24-8)/
*60*60 = arc seconds

So 0.368" per minute (yes, less than before, working on it).