### PR TITLE
STM32: Changed 2L to 4L, and 40 seconds to 120 seconds

### DIFF
--- a/OnStep.ino
+++ b/OnStep.ino
@@ -41,7 +41,7 @@
 #define FirmwareDate          __DATE__
 #define FirmwareVersionMajor  1
 #define FirmwareVersionMinor  16
-#define FirmwareVersionPatch  "c"     // for example major.minor patch: 1.3c
+#define FirmwareVersionPatch  "d"     // for example major.minor patch: 1.3c
 #define FirmwareVersionConfig 2       // internal, for tracking configuration file changes
 #define FirmwareName          "On-Step"
 #define FirmwareTime          __TIME__

--- a/Timer.ino
+++ b/Timer.ino
@@ -24,6 +24,12 @@ volatile bool axis2Powered = true;
 //--------------------------------------------------------------------------------------------------
 // Set hardware timer rates
 
+#if defined(__ARM_STM32__)
+  #define MULT      4L
+#else
+  #define MULT   1024L
+#endif
+
 // set Timer1 master sidereal clock to interval (in microseconds*16)
 volatile long isrTimerRateAxis1=0;
 volatile long isrTimerRateAxis2=0;
@@ -49,12 +55,9 @@ void timer3SetInterval(long iv) {
   // 0.0327 * 4096 = 134.21s
   uint32_t i=iv; uint16_t t=1; while (iv>65536L) { t*=2; iv=i/t; if (t==4096) { iv=65535L; break; } }
   cli(); nextAxis1Rate=iv-1L; t3rep=t; fastAxis1=(t3rep==1); sei();
-#elif defined(__ARM_STM32__)
-  uint32_t i=iv; uint16_t t=1; while (iv>65536L*2L) { t++; iv=i/t; if (t==32) { iv=65535L*2L; break; } }
-  cli(); nextAxis1Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t3rep=t; fastAxis1=(t3rep==1); sei();
 #else
   // 4.194 * 32 = 134.21s
-  uint32_t i=iv; uint16_t t=1; while (iv>65536L*1024L) { t++; iv=i/t; if (t==32) { iv=65535L*1024L; break; } }
+  uint32_t i=iv; uint16_t t=1; while (iv>65536L*MULT) { t++; iv=i/t; if (t==32) { iv=65535L*MULT; break; } }
   cli(); nextAxis1Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t3rep=t; fastAxis1=(t3rep==1); sei();
 #endif
 }
@@ -72,12 +75,9 @@ void timer4SetInterval(long iv) {
   // 0.0327 * 4096 = 134.21s
   uint32_t i=iv; uint16_t t=1; while (iv>65536L) { t*=2; iv=i/t; if (t==4096) { iv=65535L; break; } }
   cli(); nextAxis2Rate=iv-1L; t4rep=t; fastAxis2=(t4rep==1); sei();
-#elif defined(__ARM_STM32__)
-  uint32_t i=iv; uint16_t t=1; while (iv>65536L*2L) { t++; iv=i/t; if (t==32) { iv=65535L*2L; break; } }
-  cli(); nextAxis2Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t4rep=t; fastAxis2=(t4rep==1); sei();
 #else
   // 4.194 * 32 = 134.21s
-  uint32_t i=iv; uint16_t t=1; while (iv>65536L*1024L) { t++; iv=i/t; if (t==32) { iv=65535L*1024L; break; } }
+  uint32_t i=iv; uint16_t t=1; while (iv>65536L*MULT) { t++; iv=i/t; if (t==32) { iv=65535L*MULT; break; } }
   cli(); nextAxis2Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t4rep=t; fastAxis2=(t4rep==1); sei();
 #endif
 }
@@ -419,7 +419,7 @@ void autoPowerDownAxis2() {
 #if defined(PPS_SENSE_ON) || defined(PPS_SENSE_PULLUP)
 // PPS interrupt
 void clockSync() {
-  #define NUM_SECS_TO_AVERAGE 40
+  #define NUM_SECS_TO_AVERAGE 120
   unsigned long t=micros();
   unsigned long oneS=(t-PPSlastMicroS);
   if ((oneS>1000000-20000) && (oneS<1000000+20000)) {

--- a/Timer.ino
+++ b/Timer.ino
@@ -24,12 +24,6 @@ volatile bool axis2Powered = true;
 //--------------------------------------------------------------------------------------------------
 // Set hardware timer rates
 
-#if defined(__ARM_STM32__)
-  #define MULT      4L
-#else
-  #define MULT   1024L
-#endif
-
 // set Timer1 master sidereal clock to interval (in microseconds*16)
 volatile long isrTimerRateAxis1=0;
 volatile long isrTimerRateAxis2=0;
@@ -55,9 +49,13 @@ void timer3SetInterval(long iv) {
   // 0.0327 * 4096 = 134.21s
   uint32_t i=iv; uint16_t t=1; while (iv>65536L) { t*=2; iv=i/t; if (t==4096) { iv=65535L; break; } }
   cli(); nextAxis1Rate=iv-1L; t3rep=t; fastAxis1=(t3rep==1); sei();
+#elif defined(__ARM_STM32__)
+  uint32_t i=iv; uint16_t t=1; while (iv>65536L*8L) { t*=2; iv=i/t; if (t==4096) { iv=65535L; break; } }
+  cli(); nextAxis1Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5); t3rep=t; fastAxis1=(t3rep==1); sei();
+  // each count is 0.25us
 #else
   // 4.194 * 32 = 134.21s
-  uint32_t i=iv; uint16_t t=1; while (iv>65536L*MULT) { t++; iv=i/t; if (t==32) { iv=65535L*MULT; break; } }
+  uint32_t i=iv; uint16_t t=1; while (iv>65536L*1024L) { t++; iv=i/t; if (t==32) { iv=65535L*1024L; break; } }
   cli(); nextAxis1Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t3rep=t; fastAxis1=(t3rep==1); sei();
 #endif
 }
@@ -75,9 +73,12 @@ void timer4SetInterval(long iv) {
   // 0.0327 * 4096 = 134.21s
   uint32_t i=iv; uint16_t t=1; while (iv>65536L) { t*=2; iv=i/t; if (t==4096) { iv=65535L; break; } }
   cli(); nextAxis2Rate=iv-1L; t4rep=t; fastAxis2=(t4rep==1); sei();
+#elif defined(__ARM_STM32__)
+  uint32_t i=iv; uint16_t t=1; while (iv>65536L*2L) { t++; iv=i/t; if (t==32) { iv=65535L*2L; break; } }
+  cli(); nextAxis2Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t4rep=t; fastAxis2=(t4rep==1); sei();
 #else
   // 4.194 * 32 = 134.21s
-  uint32_t i=iv; uint16_t t=1; while (iv>65536L*MULT) { t++; iv=i/t; if (t==32) { iv=65535L*MULT; break; } }
+  uint32_t i=iv; uint16_t t=1; while (iv>65536L*1024L) { t++; iv=i/t; if (t==32) { iv=65535L*1024L; break; } }
   cli(); nextAxis2Rate=((F_COMP/1000000.0) * (iv*0.0625) * 0.5 - 1.0); t4rep=t; fastAxis2=(t4rep==1); sei();
 #endif
 }
@@ -419,7 +420,7 @@ void autoPowerDownAxis2() {
 #if defined(PPS_SENSE_ON) || defined(PPS_SENSE_PULLUP)
 // PPS interrupt
 void clockSync() {
-  #define NUM_SECS_TO_AVERAGE 120
+  #define NUM_SECS_TO_AVERAGE 40
   unsigned long t=micros();
   unsigned long oneS=(t-PPSlastMicroS);
   if ((oneS>1000000-20000) && (oneS<1000000+20000)) {

--- a/src/HAL/HAL_STM32F1/HAL_STM32F1.h
+++ b/src/HAL/HAL_STM32F1/HAL_STM32F1.h
@@ -68,7 +68,7 @@
 // Initialize timers
 
 // frequency compensation (F_COMP/1000000.0) for adjusting microseconds to timer counts
-#define F_COMP 1000000.0
+#define F_COMP 4000000.0
 
 void HAL_Init(void) {
   // Make sure that debug pins are not reserved, and therefore usable as GPIO
@@ -101,15 +101,16 @@ void HAL_Init_Timers_Motor() {
   // Pause the timer while we're configuring it
   Timer_Axis1.pause();
 
-  // Set up period
-  Timer_Axis1.setPeriod(128.0 * 0.0625); // in microseconds
-
-  Timer_Axis1.setPrescaleFactor(0);
-
   // Set up an interrupt on channel 3
-  Timer_Axis1.setMode(TIMER_CH1, TIMER_OUTPUT_COMPARE);
-  Timer_Axis1.setCompare(TIMER_CH1, 1);  // Interrupt 1 count after each update
-  Timer_Axis1.attachInterrupt(TIMER_CH1, TIMER3_COMPA_vect);
+  Timer_Axis1.setMode(TIMER_CH3, TIMER_OUTPUT_COMPARE);
+  Timer_Axis1.setCompare(TIMER_CH3, 1);  // Interrupt 1 count after each update
+  Timer_Axis1.attachInterrupt(TIMER_CH3, TIMER3_COMPA_vect);
+
+  // Set up period
+//  Timer_Axis1.setPeriod(100000.0);
+
+  Timer_Axis1.setPrescaleFactor(18);
+  Timer_Axis1.setOverflow(100000L/4L);
 
   // Refresh the timer's count, prescale, and overflow
   Timer_Axis1.refresh();
@@ -121,15 +122,15 @@ void HAL_Init_Timers_Motor() {
   // Pause the timer while we're configuring it
   Timer_Axis2.pause();
 
-  // Set up period
-  Timer_Axis2.setPeriod(128.0 * 0.0625); // in microseconds
-
-  Timer_Axis2.setPrescaleFactor(0);
-
   // Set up an interrupt on channel 2
-  Timer_Axis2.setMode(TIMER_CH1, TIMER_OUTPUT_COMPARE);
-  Timer_Axis2.setCompare(TIMER_CH1, 1);  // Interrupt 1 count after each update
-  Timer_Axis2.attachInterrupt(TIMER_CH1, TIMER4_COMPA_vect);
+  Timer_Axis2.setMode(TIMER_CH2, TIMER_OUTPUT_COMPARE);
+  Timer_Axis2.setCompare(TIMER_CH2, 1);  // Interrupt 1 count after each update
+  Timer_Axis2.attachInterrupt(TIMER_CH2, TIMER4_COMPA_vect);
+
+  // Set up period
+//  Timer_Axis2.setPeriod(100000.0); // in microseconds
+  Timer_Axis2.setPrescaleFactor(18);
+  Timer_Axis2.setOverflow(100000L/4L);
 
   // Refresh the timer's count, prescale, and overflow
   Timer_Axis2.refresh();
@@ -163,24 +164,16 @@ void TIMER1_COMPA_vect(void);
 HardwareTimer Timer_Sidereal(1);
 
 void Timer1SetInterval(long iv, double rateRatio) {
-
   iv=round(((double)iv)/rateRatio);
 
   Timer_Sidereal.pause();
 
+  Timer_Sidereal.setMode(TIMER_CH1, TIMER_OUTPUT_COMPARE);
+  Timer_Sidereal.setCompare(TIMER_CH1, 1);  // Interrupt 1 count after each update
+  Timer_Sidereal.attachInterrupt(TIMER_CH1, TIMER1_COMPA_vect);
+
   // Set up period
   Timer_Sidereal.setPeriod(round((double)iv * 0.0625));
-
-  static boolean firstPass = true;
-  if (firstPass) {
-    Timer_Sidereal.setPrescaleFactor(0);
-    // Set up an interrupt on channel 1
-    Timer_Sidereal.setMode(TIMER_CH1, TIMER_OUTPUT_COMPARE);
-    Timer_Sidereal.setCompare(TIMER_CH1, 1);  // Interrupt 1 count after each update
-    Timer_Sidereal.attachInterrupt(TIMER_CH1, TIMER1_COMPA_vect);
-
-    firstPass = false;
-  }
 
   // Refresh the timer's count, prescale, and overflow
   Timer_Sidereal.refresh();
@@ -193,31 +186,13 @@ void Timer1SetInterval(long iv, double rateRatio) {
 // Quickly reprogram the interval (in microseconds*(F_COMP/1000000.0)) for the motor timers, must work
 // from within the motor ISR timers
 void QuickSetIntervalAxis1(uint32_t r) {
-  // Pause the timer while we're configuring it
-  Timer_Axis1.pause();
-
   // Set up period
-  Timer_Axis1.setPeriod(r-1); // in microseconds
-
-  // Refresh the timer's count, prescale, and overflow
-  Timer_Axis1.refresh();
-
-  // Start the timer counting
-  Timer_Axis1.resume();
+  Timer_Axis1.setOverflow(r);
 }
 
 void QuickSetIntervalAxis2(uint32_t r) {
-  // Pause the timer while we're configuring it
-  Timer_Axis2.pause();
-
   // Set up period
-  Timer_Axis2.setPeriod(r-1); // in microseconds
-
-  // Refresh the timer's count, prescale, and overflow
-  Timer_Axis2.refresh();
-
-  // Start the timer counting
-  Timer_Axis2.resume();
+  Timer_Axis2.setOverflow(r);
 }
 
 // --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change provides the same tracking on very low Steps Per Degrees (1,777.777) GEMs, and good tracking for Alt-Az, and much better tracking on high Steps Per Degrees (28,800).

It also makes the code go back to its original form: only two code segments one for Arduino and the other for everything else. That is, there is no special segment for the STM32, duplicating portions of code.

Here are the test results. They are on Rasalhague in Ophiuchus.

4L, 120 seconds, 28,800 steps/deg, 
GEM, Khalid
3 hour test
0.065"/minute drift in RA

2018-11-16 17:58:22 03:25:28#+49*56:21# 51.366146,49.939201  0.000  0.000
2018-11-16 17:59:22 03:25:28#+49*56:21# 51.366181,49.939201  0.126  0.000
2018-11-16 18:00:23 03:25:28#+49*56:21# 51.366181,49.939201  0.063  0.000
2018-11-16 18:01:23 03:25:28#+49*56:21# 51.366222,49.939201  0.091  0.000
2018-11-16 18:02:23 03:25:28#+49*56:21# 51.366257,49.939201  0.100  0.000
2018-11-16 18:03:23 03:25:28#+49*56:21# 51.366285,49.939201  0.100  0.000
2018-11-16 18:04:23 03:25:28#+49*56:21# 51.366285,49.939201  0.083  0.000
...
2018-11-16 19:04:17 03:25:28#+49*56:21# 51.367340,49.939201  0.000  0.000
2018-11-16 19:05:18 03:25:28#+49*56:21# 51.367340,49.939201  0.000  0.000
2018-11-16 19:06:18 03:25:28#+49*56:21# 51.367375,49.939201  0.063  0.000
2018-11-16 19:07:18 03:25:28#+49*56:21# 51.367403,49.939201  0.076  0.000
2018-11-16 19:08:18 03:25:28#+49*56:21# 51.367417,49.939201  0.069  0.000
2018-11-16 19:09:18 03:25:28#+49*56:21# 51.367417,49.939201  0.055  0.000
...
2018-11-16 20:05:17 03:25:28#+49*56:21# 51.368451,49.939201  0.000  0.000
2018-11-16 20:06:17 03:25:28#+49*56:21# 51.368486,49.939201  0.126  0.000
2018-11-16 20:07:18 03:25:28#+49*56:21# 51.368521,49.939201  0.126  0.000
2018-11-16 20:08:18 03:25:28#+49*56:21# 51.368521,49.939201  0.084  0.000
2018-11-16 20:09:18 03:25:28#+49*56:21# 51.368507,49.939201  0.063  0.000
2018-11-16 20:10:18 03:25:28#+49*56:21# 51.368549,49.939201  0.071  0.000
...
2018-11-16 21:05:05 03:25:29#+49*56:21# 51.369556,49.939201  0.000  0.000
2018-11-16 21:06:05 03:25:29#+49*56:21# 51.369556,49.939201  0.000  0.000
2018-11-16 21:07:06 03:25:29#+49*56:21# 51.369590,49.939201  0.061  0.000
2018-11-16 21:08:06 03:25:29#+49*56:21# 51.369625,49.939201  0.083  0.000
2018-11-16 21:09:06 03:25:29#+49*56:21# 51.369625,49.939201  0.062  0.000
2018-11-16 21:10:06 03:25:29#+49*56:21# 51.369618,49.939201  0.050  0.000

4L, 120 seconds, 1,777.777 steps/degree, 
GEM, Verloop
10 minute test
0.33"/minute drift in RA
2018-11-17 09:50:23 17:35:39 +12*34:21 263.912625,12.572438  0.000  0.000
2018-11-17 09:51:24 17:35:39 +12*34:21 263.912792,12.572438  0.601  0.000
2018-11-17 09:52:24 17:35:39 +12*34:21 263.912479,12.572438  0.563  0.000
2018-11-17 09:53:24 17:35:39 +12*34:21 263.912646,12.572438  0.375  0.000
2018-11-17 09:54:24 17:35:39 +12*34:21 263.912896,12.572438  0.375  0.000
2018-11-17 09:55:24 17:35:39 +12*34:21 263.912542,12.572438  0.299  0.000
2018-11-17 09:56:25 17:35:39 +12*34:21 263.912750,12.572438  0.249  0.000
2018-11-17 09:57:25 17:35:39 +12*34:21 263.912396,12.572438  0.256  0.000
2018-11-17 09:58:25 17:35:39 +12*34:21 263.912042,12.572438  0.383  0.000
2018-11-17 09:59:25 17:35:39 +12*34:21 263.912292,12.572438  0.341  0.000
2018-11-17 10:00:25 17:35:39 +12*34:21 263.911979,12.572438  0.329  0.000

4L, 120 seconds, 12214.793 steps/degree
Alt-Az, Zeppy
10 minute test
0.12"/minute in RA, 0.106"/minute in DEC
2018-11-17 10:05:41 17:34:57 +12*33:07 263.737601,12.551841  0.000
2018-11-17 10:06:42 17:34:57 +12*33:07 263.737561,12.551852  0.144
2018-11-17 10:07:42 17:34:57 +12*33:07 263.737527,12.551941  0.133
2018-11-17 10:08:42 17:34:57 +12*33:07 263.737538,12.551892  0.089
2018-11-17 10:09:42 17:34:57 +12*33:07 263.737470,12.551980  0.118
2018-11-17 10:10:42 17:34:57 +12*33:07 263.737458,12.551993  0.103
2018-11-17 10:11:43 17:34:57 +12*33:07 263.737417,12.551996  0.110
2018-11-17 10:12:43 17:34:57 +12*33:07 263.737375,12.551990  0.116
2018-11-17 10:13:43 17:34:57 +12*33:07 263.737351,12.552083  0.112
2018-11-17 10:14:43 17:34:57 +12*33:07 263.737314,12.552076  0.114
2018-11-17 10:15:43 17:34:57 +12*33:08 263.737278,12.552138  0.116

This should be the last thing to go into the code for the STM32 tracking accuracy issue, unless we get new reports. 

If you have any issue with the code, please don't close the issue. Let us discuss it and I will change it,  until we reach an agreement. 