### PR TITLE
Compatibility with other PCBs

### DIFF
--- a/addons/St4Serial/SmartHandController/README.md
+++ b/addons/St4Serial/SmartHandController/README.md
@@ -2,12 +2,24 @@ OnStep Smart Hand Controller
 ===========================
 
 # What is a smart hand controller (SHC)?
-This firmware is designed to run on a Teensy3.2 micro-controller which communicates with OnStep across the ST4 guiding port to provide
-setup and control of most features.  This is largely (almost entirely at the moment) based on Charles Lemaire's excellent TeenAstro work.
-While you can point to point wire/assemble you own hardware design many will opt to use the inexpensive 
-EasyEDA PCB.  For those who choose a more complete DIY experience the EasyEDA schematic still can serve as wiring instructions. :)
+This firmware is designed to run on a supported smart hand controller hardware to communicate
+with an OnStep controller over the ST4 guiding port. Most of the setup and control functions
+are available.
 
-https://easyeda.com/hdutton/HC-20e242d665db4c85bb565a0cd0b52233
+This is almost entirely based on Charles Lemaire's excellent TeenAstro work.
+
+At present, there are two hardware designs:
+a) Teensy3.2 microcontroller
+
+While you can point to point wire/assemble you own hardware design many will opt to use the
+inexpensive [EasyEDA Teensy SHC PCB](https://easyeda.com/hdutton/HC-20e242d665db4c85bb565a0cd0b52233).
+For those who choose a more complete DIY experience the EasyEDA schematic still can serve as wiring
+instructions. :)
+
+b) ESP32 microcontroller. This offers a lower cost easier to source alternative to the 
+Teensy above, with the same features. 
+
+The PCB can be found in the following link (to be announced soon).
 
 # Features
 The SHC can:
@@ -15,10 +27,32 @@ The SHC can:
 * Set Site (Latitude/Longitude) and Time.
 * Configure most options.  Backlash, limits, etc.
 * Center objects and operate focuser/rotator.
-* Goto stars and deep sky objects.
+* Goto stars, Messier, and Herschel deep sky objects.
 
 # Documentation
-None available yet.
+
+See this [Wiki page](https://groups.io/g/onstep/wiki/Smart-Hand-Controller) for more info.
+
+In a nutshell ...
+
+The main display is the RA and Dec that the telescope is currently pointing at.
+A small telescope icon with an H under it, means the telescope is in the Home position
+When the telescope is slewing, a double triangle with show. When it is tracking, a single
+triangle will show, as well as the pier side, and the tracking rate ('s' for sidereal).
+
+- Press any of the N, S, W, E buttons to move the telescope 
+- Press the center button to wake up the screen
+- Press it again to cycle through status displays (RA/Dec coordinates, Alt-Az coords, Time)
+
+- Quickly press the center button twice to get to the Speed menu
+- Long press the center button for the menu
+  * Goto
+  * Sync
+  * Align
+  * Parking
+  * PEC
+  * Settings
+- Select a menu by the Up or Down button, then Right to enter that menu
 
 # Support
 Questions and discussion should be on the mailing list (also accessible via the
@@ -30,4 +64,4 @@ OnStep is open source free software, licensed under the GPL.
 See [LICENSE.txt](./LICENSE.txt) file.
 
 # Author
-Charles Lemaire, [Howard Dutton](http://www.stellarjourney.com)
+Charles Lemaire, [Howard Dutton](http://www.stellarjourney.com), and [Khalid Baheyeldin](https://baheyeldin.com)

--- a/addons/St4Serial/SmartHandController/SHC_Config.h
+++ b/addons/St4Serial/SmartHandController/SHC_Config.h
@@ -14,6 +14,10 @@
   // SSD1306 is the 0.96"
   //#define OLED_DISPLAY SSD1306
 
+  // Configure defaults for display dimming and blanking (in milliseconds, 0 disables)
+  #define DISPLAY_DIM_TIME     30000        // original value 30000
+  #define DISPLAY_BLANK_TIME  120000        // original value 120000
+
   // The serial interface to/from OnStep
   #define Ser SerialST4             // You could also, for example, use the Teensy3.2's Serial3 interface "Ser Serial3"
   #define SERIAL_BAUD_DEFAULT 57200 // Default=57200, only used for async comms (not SerialST4)

--- a/addons/St4Serial/SmartHandController/SHC_Config.h
+++ b/addons/St4Serial/SmartHandController/SHC_Config.h
@@ -10,9 +10,9 @@
   // Select the display type by commenting out the one you don't use, and leaving the other one commented out
 
   // SH1106 is the 1.3"
-  //#define OLED_DISPLAY SH1106
+  #define OLED_DISPLAY SH1106
   // SSD1306 is the 0.96"
-  #define OLED_DISPLAY SSD1306
+  //#define OLED_DISPLAY SSD1306
 
   // The serial interface to/from OnStep
   #define Ser SerialST4             // You could also, for example, use the Teensy3.2's Serial3 interface "Ser Serial3"
@@ -60,10 +60,10 @@
     #define B_PIN5 39   // F
     #define B_PIN6 35   // f
 
-    #define ST4RAw 26   // ST4 RA- West,  send data to OnStep
-    #define ST4DEs 27   // ST4 DE- South, clock input to ISR
-    #define ST4DEn 14   // ST4 DE+ North, recv data from OnStep
-    #define ST4RAe 23   // ST4 RA+ East,  always 12.5 Hz square wave on this pin
+    #define ST4RAw 23   // ST4 RA- West,  send data to OnStep
+    #define ST4DEs 14   // ST4 DE- South, clock input to ISR
+    #define ST4DEn 27   // ST4 DE+ North, recv data from OnStep
+    #define ST4RAe 26   // ST4 RA+ East,  always 12.5 Hz square wave on this pin
   #endif 
 
   #include "St4SerialSlave.h"

--- a/addons/St4Serial/SmartHandController/SmartController.cpp
+++ b/addons/St4Serial/SmartHandController/SmartController.cpp
@@ -278,8 +278,8 @@ void SmartHandController::update()
     if (sleepDisplay) { display->setContrast(maxContrast); display->sleepOff(); sleepDisplay = false; lowContrast = false; buttonPad.clearAllPressed(); time_last_action = millis(); }
     if (lowContrast)  { display->setContrast(maxContrast); lowContrast = false; time_last_action = top; }
   } else if (sleepDisplay) return;
-  if (top - time_last_action > 120000) { display->sleepOn(); sleepDisplay = true; return; }
-  if (top - time_last_action > 30000 && !lowContrast) { display->setContrast(0); lowContrast = true; return; }
+  if (DISPLAY_BLANK_TIME && top - time_last_action > DISPLAY_BLANK_TIME) { display->sleepOn(); sleepDisplay = true; return; }
+  if (DISPLAY_DIM_TIME   && top - time_last_action > DISPLAY_DIM_TIME && !lowContrast) { display->setContrast(0); lowContrast = true; return; }
 
   // power cycle reqd message
   if (powerCylceRequired) { display->setFont(u8g2_font_helvR12_tr); DisplayMessage("REBOOT", "DEVICE", 1000); return; }
@@ -1377,4 +1377,3 @@ bool SmartHandController::DisplayMessageLX200(LX200RETURN val, bool silentOk)
   }
   return isOk(val);
 }
-

--- a/addons/St4Serial/SmartHandController/SmartController.cpp
+++ b/addons/St4Serial/SmartHandController/SmartController.cpp
@@ -190,6 +190,9 @@ static const unsigned char teenastro_bits[] U8X8_PROGMEM = {
   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 
+unsigned long display_blank_time = DISPLAY_BLANK_TIME;
+unsigned long display_dim_time = DISPLAY_DIM_TIME;  
+
 void gethms(const long& v, uint8_t& v1, uint8_t& v2, uint8_t& v3)
 {
   v3 = v % 60;
@@ -278,8 +281,8 @@ void SmartHandController::update()
     if (sleepDisplay) { display->setContrast(maxContrast); display->sleepOff(); sleepDisplay = false; lowContrast = false; buttonPad.clearAllPressed(); time_last_action = millis(); }
     if (lowContrast)  { display->setContrast(maxContrast); lowContrast = false; time_last_action = top; }
   } else if (sleepDisplay) return;
-  if (DISPLAY_BLANK_TIME && top - time_last_action > DISPLAY_BLANK_TIME) { display->sleepOn(); sleepDisplay = true; return; }
-  if (DISPLAY_DIM_TIME   && top - time_last_action > DISPLAY_DIM_TIME && !lowContrast) { display->setContrast(0); lowContrast = true; return; }
+  if (display_blank_time && top - time_last_action > display_blank_time) { display->sleepOn(); sleepDisplay = true; return; }
+  if (display_dim_time && top - time_last_action > display_dim_time && !lowContrast) { display->setContrast(0); lowContrast = true; return; }
 
   // power cycle reqd message
   if (powerCylceRequired) { display->setFont(u8g2_font_helvR12_tr); DisplayMessage("REBOOT", "DEVICE", 1000); return; }
@@ -933,7 +936,7 @@ void SmartHandController::menuPier()
 
 void SmartHandController::menuDisplay()
 {
-  const char *string_list_Display = "Turn Off\nContrast";
+  const char *string_list_Display = "Turn Off\nContrast\nDim Timeout\nBlank Timeout";
   current_selection_L2 = 1;
   while (current_selection_L2 != 0)
   {
@@ -950,6 +953,12 @@ void SmartHandController::menuDisplay()
       break;
     case 2:
       menuContrast();
+      break;
+    case 3:
+      menuDimTimeout();
+      break;
+    case 4:
+      menuBlankTimeout();
       break;
     default:
       break;
@@ -1216,6 +1225,34 @@ void SmartHandController::menuContrast()
   }
 }
 
+void SmartHandController::menuDimTimeout()
+{
+  const char *string_list_Display = "Disable\n30 sec\n60 sec";
+  current_selection_L3 = 2;
+
+  if (current_selection_L3 > 0)
+  {
+    current_selection_L3 = display->UserInterfaceSelectionList(&buttonPad, "Dim Timeout", current_selection_L3, string_list_Display);
+    display_dim_time = (current_selection_L3 - 1) * 30000;
+    //EEPROM.writeLong(16, display_dim_time);
+    //EEPROM.commit();
+  }
+}
+
+void SmartHandController::menuBlankTimeout()
+{
+  const char *string_list_Display = "Disable\n1 min\n2 min\n3 min\n4 min\n5 min";
+  current_selection_L3 = 3;
+
+  if (current_selection_L3 > 0)
+  {
+    current_selection_L3 = display->UserInterfaceSelectionList(&buttonPad, "Blank Timeout", current_selection_L3, string_list_Display);
+    display_blank_time = (current_selection_L3 - 1) * 60 * 1000;
+    //EEPROM.writeLong(20, display_blank_time);
+    //EEPROM.commit();
+  }
+}
+
 void SmartHandController::DisplayMessage(const char* txt1, const char* txt2, int duration)
 {
   uint8_t x;
@@ -1377,3 +1414,4 @@ bool SmartHandController::DisplayMessageLX200(LX200RETURN val, bool silentOk)
   }
   return isOk(val);
 }
+

--- a/addons/St4Serial/SmartHandController/SmartController.h
+++ b/addons/St4Serial/SmartHandController/SmartController.h
@@ -81,6 +81,8 @@ private:
   void menuMeridianFlips();
   void menuTracking();
   void menuContrast();
+  void menuDimTimeout();
+  void menuBlankTimeout();
   void menuLatitude();
   void menuLongitude();
   void menuZone();
@@ -107,4 +109,3 @@ private:
   bool DisplayMessageLX200(LX200RETURN val, bool silentOk = true);
 };
 extern SmartHandController HdCrtlr;
-

--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -50,10 +50,10 @@
   #define A2ST          PA0
   #define A2DR          PC15
 
-  #define S4N           PA6 
-  #define S4S           PA7
-  #define S4W           PB0
-  #define S4E           PB1
+  #define S4N           PA7
+  #define S4S           PA6
+  #define S4W           PB1
+  #define S4E           PB0
 
   #define LED           PC13
 


### PR DESCRIPTION
Changed the pinmap for the STM32's ST4 port to conform to MaxPCB, MiniPCB, and MaxESP. This way, the ESP32 SHC will work for all these platforms. Verified to work.

Also Dave Schwartz made the dimming and blanking milliseconds a menu option, rather than hard coded values. . 

At least the first change needs to go into Beta, so if someone is using that, their ST4 is compatible with any SHC.