### PR TITLE
ST4 pins changes

### DIFF
--- a/src/pinmaps/Pins.STM32B.h
+++ b/src/pinmaps/Pins.STM32B.h
@@ -50,10 +50,10 @@
   #define A2ST          PA0
   #define A2DR          PC15
 
-  #define S4N           PA6 
-  #define S4S           PA7
-  #define S4W           PB0
-  #define S4E           PB1
+  #define S4N           PA7
+  #define S4S           PA6
+  #define S4W           PB1
+  #define S4E           PB0
 
   #define LED           PC13
 


### PR DESCRIPTION
The ST4 pinmap for STM32 was not compatible with other OnStep PCBs.

This change to Beta makes sure that an SHC will work across PCBs.

Change is already in Alpha.