### PR TITLE
Fix for wrong time label: it is actually local time, but labeled as UTC.

### DIFF
--- a/addons/St4Serial/SmartHandController/SmartController.cpp
+++ b/addons/St4Serial/SmartHandController/SmartController.cpp
@@ -499,9 +499,9 @@ void SmartHandController::updateMainDisplay( u8g2_uint_t page)
     if (page == 2) {
       if (telInfo.hasInfoUTC && telInfo.hasInfoSidereal)
       {
-        char us[20]; strcpy(us,telInfo.TempUTC); us[2]=0; us[5]=0;
+        char us[20]; strcpy(us,telInfo.TempLocalTime); us[2]=0; us[5]=0;
         x = u8g2_GetDisplayWidth(u8g2);  u8g2_uint_t y = 36;
-        u8g2_DrawUTF8(u8g2, 0, y, "UTC"); display->drawRA( x, y, us, &us[3], &us[6]);
+        u8g2_DrawUTF8(u8g2, 0, y, "Local"); display->drawRA( x, y, us, &us[3], &us[6]);
 
         char ss[20]; strcpy(ss,telInfo.TempSidereal); ss[2]=0; ss[5]=0;
         y += line_height + 4;

--- a/addons/St4Serial/SmartHandController/Telescope.cpp
+++ b/addons/St4Serial/SmartHandController/Telescope.cpp
@@ -21,7 +21,7 @@ void Telescope::updateTime(boolean immediate)
 {
   if ((millis() - lastStateTime > BACKGROUND_CMD_RATE) && ((updateSeq%4==2) || (updateSeq%4==3) || immediate) && connected)
   {
-    if ((updateSeq%4==2) || immediate) { hasInfoUTC = GetLX200(":GL#", TempUTC) == LX200VALUEGET; if (!hasInfoUTC) connected = true; }
+    if ((updateSeq%4==2) || immediate) { hasInfoUTC = GetLX200(":GL#", TempLocalTime) == LX200VALUEGET; if (!hasInfoUTC) connected = true; }
     if ((updateSeq%4==3) || immediate) { hasInfoSidereal = GetLX200(":GS#", TempSidereal) == LX200VALUEGET; if (!hasInfoSidereal) connected = true; lastStateTime = millis(); }
   }
 };

--- a/addons/St4Serial/SmartHandController/Telescope.h
+++ b/addons/St4Serial/SmartHandController/Telescope.h
@@ -39,7 +39,7 @@ public:
   char TempAz[20];
   char TempAlt[20];
   unsigned long lastStateAzAlt;
-  char TempUTC[20];
+  char TempLocalTime[20];
   char TempSidereal[20];
   unsigned long lastStateTime;
   char TelStatus[20];


### PR DESCRIPTION
The display said: UTC but in fact this is the correct local time, and retrieved using :GL#.

Fixed the label. 