### PR TITLE
Eliminating most SHC compiler warnings.

### DIFF
--- a/addons/St4Serial/SmartHandController/Catalog.cpp
+++ b/addons/St4Serial/SmartHandController/Catalog.cpp
@@ -293,7 +293,10 @@ bool CatMgr::isFiltered() {
       if (_lat >= 0.0) ad = 45.0; else ad = -45.0;
       if (DistFromEqu(ar,ad)>30.0) return true;
       return false;
-      break;
+    break;
+    default:
+      return false;
+    break;
   }
 }
 

--- a/addons/St4Serial/SmartHandController/Catalog.cpp
+++ b/addons/St4Serial/SmartHandController/Catalog.cpp
@@ -201,6 +201,7 @@ void CatMgr::setLat(double lat) {
   }
 }
 
+// Set Local Sidereal Time, and number of milliseconds
 void CatMgr::setLstT0(double lstT0) {
   _lstT0=lstT0;
   _lstMillisT0=millis();
@@ -210,13 +211,15 @@ bool CatMgr::isInitialized() {
   return ((_lat<9999) && (_lstT0!=0));
 }
 
-// time
+// Get Local Sidereal Time, converted from hours to degrees
 double CatMgr::lstDegs() {
   return (lstHours()*15.0);
 }
 
+// Get Local Sidereal Time, in hours, and adjust for time inside the menus
 double CatMgr::lstHours() {
   double msSinceT0=(unsigned long)(millis()-_lstMillisT0);
+  // Convert from Solar to Sidereal
   double siderealSecondsSinceT0=(msSinceT0/1000.0)*1.00277778;
   return _lstT0+siderealSecondsSinceT0/3600.0;
 }
@@ -229,10 +232,12 @@ void CatMgr::select(Catalog cat) {
   if (_cat==HERSCHEL) _selected=2; else { _selected=0; _cat=CAT_NONE; }
 }
 
+// Get active catalog
 Catalog CatMgr::getCat() {
   return _cat;
 }
 
+// Get active catalog description
 const char* CatMgr::catalogStr() {
   return Txt_Catalog[_selected];
 }
@@ -335,7 +340,7 @@ void CatMgr::decIndex() {
 
 // get catalog contents
 
-// RA in degrees
+// RA, converted from hours to degrees
 double CatMgr::ra() {
   return rah()*15.0;
 }
@@ -358,6 +363,7 @@ double CatMgr::ha() {
   return h;
 }
 
+// Get RA of an object, in hours, as HH:MM:SS
 void CatMgr::raHMS(uint8_t& h, uint8_t& m, uint8_t& s) {
   double f;
   if (_cat==STAR)     f=Cat_Stars[_idx[_selected]].RA; else
@@ -386,6 +392,7 @@ double CatMgr::dec() {
   return f;
 }
 
+// Declination as DD:MM:SS
 void CatMgr::decDMS(short& d, uint8_t& m, uint8_t& s) {
   double f;
   if (_cat==STAR)     f=Cat_Stars[_idx[_selected]].DE; else
@@ -406,6 +413,7 @@ void CatMgr::decDMS(short& d, uint8_t& m, uint8_t& s) {
   s = (int)s1;
 }
 
+// Epoch for catalog
 int CatMgr::epoch() {
   if (_cat==STAR) return 2000; else
   if (_cat==MESSIER) return 2000; else
@@ -439,6 +447,7 @@ void CatMgr::topocentricToObservedPlace(float *RA, float *Dec) {
   }
 }
 
+// Magnitude of an object
 double CatMgr::magnitude() {
   double m=250;
   if (_cat==STAR)     m=Cat_Stars[_idx[_selected]].Mag; else
@@ -447,33 +456,39 @@ double CatMgr::magnitude() {
   return m/100.0;
 }
 
+// Constellation number for an object
 byte CatMgr::constellation() {
   if (_cat==STAR)     return Cat_Stars[_idx[_selected]].Cons; else
   if (_cat==MESSIER)  return Cat_Messier[_idx[_selected]].Cons; else
   if (_cat==HERSCHEL) return Cat_Herschel[_idx[_selected]].Cons; else return 89;
 }
 
+// Constellation string, from constellation number
 const char* CatMgr::constellationStr() {
   return Txt_Constellations[constellation()];
 }
 
+// Object type number
 byte CatMgr::objectType() {
   if (_cat==MESSIER)  return Cat_Messier[_idx[_selected]].Obj_type; else
   if (_cat==HERSCHEL) return Cat_Herschel[_idx[_selected]].Obj_type; else return -1;
 }
 
+// Object type string
 const char* CatMgr::objectTypeStr() {
   if (_cat==STAR)     return "Star"; else
   if (_cat==MESSIER)  return Txt_Object_Type[objectType()]; else
   if (_cat==HERSCHEL) return Txt_Object_Type[objectType()]; else return "";
 }
 
+// Object name
 const char* CatMgr::objectName() {
   if (_cat==STAR)     return Cat_Stars[_idx[_selected]].Name; else
   if (_cat==MESSIER)  return ""; else
   if (_cat==HERSCHEL) return ""; else return "";
 }
 
+// Object ID
 int CatMgr::primaryId() {
   if (_cat==STAR)     return Cat_Stars[_idx[_selected]].Bayer + 1; else
   if (_cat==MESSIER)  return Cat_Messier[_idx[_selected]].Obj_id; else
@@ -496,8 +511,6 @@ double CatMgr::HAToRA(double HA) {
 // convert equatorial coordinates to horizon, in degrees
 void CatMgr::EquToHor(double RA, double Dec, double *Alt, double *Azm) {
   double HA=lstDegs()-RA;
-  //D("RA="); D(RA);
-  //D(",DE="); D(Dec);
   while (HA<0.0)    HA=HA+360.0;
   while (HA>=360.0) HA=HA-360.0;
   HA =HA/Rad;
@@ -509,7 +522,6 @@ void CatMgr::EquToHor(double RA, double Dec, double *Alt, double *Azm) {
   *Azm=atan2(t1,t2)*Rad;
   *Azm=*Azm+180.0;
   *Alt = *Alt*Rad;
-  //D(",Alt="); DL(*Alt);
 }
 
 // convert horizon coordinates to equatorial, in degrees

--- a/addons/St4Serial/SmartHandController/LX200.cpp
+++ b/addons/St4Serial/SmartHandController/LX200.cpp
@@ -158,6 +158,11 @@ LX200RETURN SetLX200(char* command)
     return LX200SETVALUEFAILED;
 }
 
+LX200RETURN SetLX200(const char* command)
+{
+  return SetLX200((char *)command);
+}
+
 LX200RETURN GetLX200(char* command, char* output)
 {
   memset(output, 0, sizeof(output));
@@ -165,6 +170,11 @@ LX200RETURN GetLX200(char* command, char* output)
     return LX200VALUEGET;
   else
     return LX200GETVALUEFAILED;
+}
+
+LX200RETURN GetLX200(const char* command, char* output)
+{
+  return GetLX200((char *)command, output);
 }
 
 LX200RETURN GetLX200Trim(char* command, char* output)
@@ -175,6 +185,11 @@ LX200RETURN GetLX200Trim(char* command, char* output)
     return LX200VALUEGET;
   } else
     return LX200GETVALUEFAILED;
+}
+
+LX200RETURN GetLX200Trim(const char* command, char* output)
+{
+  return GetLX200Trim((char *)command, output);
 }
 
 LX200RETURN GetTimeLX200(unsigned int &hour, unsigned int &minute, unsigned int &second, boolean ut)
@@ -193,7 +208,8 @@ LX200RETURN GetTimeLX200(unsigned int &hour, unsigned int &minute, unsigned int 
 LX200RETURN GetTimeLX200(long &value, boolean ut)
 {
   unsigned int hour, minute, second;
-  if (!GetTimeLX200(hour, minute, second, ut) == LX200GETVALUEFAILED) return LX200GETVALUEFAILED;
+  // this had a not (!) before GetTimeLX200 below, no reason it should be there?
+  if (GetTimeLX200(hour, minute, second, ut) == LX200GETVALUEFAILED) return LX200GETVALUEFAILED;
   value = hour * 60 + minute;
   value *= 60;
   value += second;
@@ -236,7 +252,7 @@ LX200RETURN Move2TargetLX200()
 {
   char out[20];
   memset(out, 0, sizeof(out));
-  int val = readLX200Bytes(":MS#", out, TIMEOUT_CMD);
+  readLX200Bytes((char *)":MS#", out, TIMEOUT_CMD);
   LX200RETURN response;
   switch (out[0]-'0')
   {
@@ -284,7 +300,7 @@ LX200RETURN SetTargetRaLX200(int vr1, int vr2, int vr3)
       {
         unsigned int hour, minute, second;
         char2RA(out, hour, minute, second);
-        if (hour == vr1 && minute == vr2 && second == vr3)
+        if ((int)hour == vr1 && (int)minute == vr2 && (int)second == vr3)
         {
           return LX200VALUESET;
         }
@@ -310,7 +326,7 @@ LX200RETURN SetTargetDecLX200(char sign, int vd1, int vd2, int vd3)
         int deg;
         unsigned int min, sec;
         char2DEC(out, deg, min, sec);
-        if (out[0]==sign && abs(deg) == vd1 && min == vd2 && sec == vd3)
+        if (out[0]==sign && abs(deg) == vd1 && (int)min == vd2 && (int)sec == vd3)
         {
           return LX200VALUESET;
         }
@@ -365,7 +381,7 @@ LX200RETURN GetDateLX200(unsigned int &day, unsigned int &month, unsigned int &y
 LX200RETURN SyncGotoCatLX200(bool sync)
 {
   int epoch;
-  unsigned int day, month, year, hour, minute, second;
+  unsigned int day, month, year;
   if (GetDateLX200(day, month, year, true) == LX200GETVALUEFAILED) return LX200GETVALUEFAILED;
   if (cat_mgr.getCat()==CAT_NONE) return LX200UNKOWN;
   EquatorialCoordinates coo;
@@ -379,7 +395,6 @@ LX200RETURN SyncGotoCatLX200(bool sync)
 
 LX200RETURN SyncGotoPlanetLX200(bool sync, unsigned short objSys)
 {
-  char out[20];
   unsigned int day, month, year, hour, minute, second;
 
   if (GetDateLX200(day, month, year, true) == LX200GETVALUEFAILED) return LX200GETVALUEFAILED;

--- a/addons/St4Serial/SmartHandController/LX200.h
+++ b/addons/St4Serial/SmartHandController/LX200.h
@@ -9,10 +9,13 @@ enum LX200RETURN {
 
 bool isOk(LX200RETURN val);
 LX200RETURN GetLX200(char* command, char* output);
+LX200RETURN GetLX200(const char* command, char* output); // overloaded to allow const char* strings without compiler warnings, similar follow below
 LX200RETURN GetLX200Trim(char* command, char* output);
+LX200RETURN GetLX200Trim(const char* command, char* output);
 LX200RETURN GetTimeLX200(unsigned int &hour, unsigned int &minute, unsigned int &second, boolean ut=false);
 LX200RETURN GetTimeLX200(long &value, boolean ut=false);
 LX200RETURN SetLX200(char* command);
+LX200RETURN SetLX200(const char* command);
 LX200RETURN SetTimeLX200(long &value);
 LX200RETURN GetSiteLX200(int &value);
 void SetSiteLX200(int &value);
@@ -41,5 +44,3 @@ LX200RETURN writeHighCurrLX200(const uint8_t &axis, const uint8_t &highCurr);
 
 boolean hmsToDouble(double *f, char *hms);
 boolean dmsToDouble(double *f, char *dms, boolean sign_present, boolean highPrecision);
-
-

--- a/addons/St4Serial/SmartHandController/MenuAlignment.h
+++ b/addons/St4Serial/SmartHandController/MenuAlignment.h
@@ -33,14 +33,12 @@ void SmartHandController::menuAlignment()
             case 7: telInfo.aliMode = Telescope::ALIM_SEVEN; break;
             case 8: telInfo.aliMode = Telescope::ALIM_EIGHT; break;
             case 9: telInfo.aliMode = Telescope::ALIM_NINE; break;
-            defualt: break;
           }
           current_selection_L1 = 0; current_selection_L0 = 0; // Quit Menu
         break;
         case 2: showAlign=true; break;
         case 3: clearAlign=true; break;
         case 4: resetAlign=true; break;
-        default: break;
       }
     } else
     if ((maxAlignStars==1) || (maxAlignStars==2)) {
@@ -49,7 +47,6 @@ void SmartHandController::menuAlignment()
       switch (current_selection_L1) {
         case 1: starsForAlign=1; break;
         case 2: resetAlign=true; break;
-        default: break;
       }
     } else
     if (maxAlignStars==3) {
@@ -58,7 +55,6 @@ void SmartHandController::menuAlignment()
       switch (current_selection_L1) {
         case 1: starsForAlign=1; break; case 2: starsForAlign=2; break; case 3: starsForAlign=3; break;
         case 4: showAlign=true; break;  case 5: clearAlign=true; break; case 6: resetAlign=true; break;
-        default: break;
       }
     } else
     if ((maxAlignStars==4) || (maxAlignStars==5)) {
@@ -67,7 +63,6 @@ void SmartHandController::menuAlignment()
       switch (current_selection_L1) {
         case 1: starsForAlign=1; break; case 2: starsForAlign=3; break; case 3: starsForAlign=4; break;
         case 4: showAlign=true; break;  case 5: clearAlign=true; break; case 6: resetAlign=true; break;
-        default: break;
       }
     } else
     if (maxAlignStars==6) {
@@ -76,7 +71,6 @@ void SmartHandController::menuAlignment()
       switch (current_selection_L1) {
         case 1: starsForAlign=1; break; case 2: starsForAlign=3; break; case 3: starsForAlign=4; break; case 4: starsForAlign=6; break;
         case 5: showAlign=true; break;  case 6: clearAlign=true; break; case 7: resetAlign=true; break;
-        default: break;
       }
     } else
     if (maxAlignStars==9) {
@@ -85,7 +79,6 @@ void SmartHandController::menuAlignment()
       switch (current_selection_L1) {
         case 1: starsForAlign=1; break; case 2: starsForAlign=3; break; case 3: starsForAlign=6; break; case 4: starsForAlign=9; break;
         case 5: showAlign=true; break;  case 6: clearAlign=true; break; case 7: resetAlign=true; break;
-        default: break;
       }
     }
   

--- a/addons/St4Serial/SmartHandController/MenuMount.h
+++ b/addons/St4Serial/SmartHandController/MenuMount.h
@@ -13,7 +13,6 @@ void SmartHandController::menuMount()
     case 2: menuBacklash(); break;
     case 3: menuLimits(); break;
     case 4: menuPier(); break;
-    default: break;
     }
   }
 }
@@ -47,7 +46,6 @@ void SmartHandController::menuGotoSpeed()
     case 3: SetLX200(":SX93,3#"); DisplayMessage("Goto Speed", "1X", 1500); break;
     case 4: SetLX200(":SX93,4#"); DisplayMessage("Goto Speed", "0.75X", 1500); break;
     case 5: SetLX200(":SX93,5#"); DisplayMessage("Goto Speed", "0.5X", 1500); break;
-    default: break;
     }
   }
 }
@@ -110,8 +108,6 @@ void SmartHandController::menuLimits()
       break;
     case 4:
       menuMeridianW();
-      break;
-    default:
       break;
     }
   }

--- a/addons/St4Serial/SmartHandController/MenuSettings.h
+++ b/addons/St4Serial/SmartHandController/MenuSettings.h
@@ -14,9 +14,8 @@ void SmartHandController::menuSettings()
       case 2: menuDisplay(); break;
       case 3: menuSound(); break;
       case 4: menuMeridianFlips(); break;
-      case 5: menuMount(); break; // Configuration
+      case 5: menuMount(); break;
       case 6: menuSite(); break;
-      default: break;
       }
     } else {
       const char *string_list_SettingsL1 = "Date/Time\n""Display\n""Buzzer\n""Configuration\n""Site";
@@ -26,9 +25,8 @@ void SmartHandController::menuSettings()
       case 1: menuLocalDateTime(); break;
       case 2: menuDisplay(); break;
       case 3: menuSound(); break;
-      case 4: menuMount(); break; // Configuration
+      case 4: menuMount(); break;
       case 5: menuSite(); break;
-      default: break;
       }
     }
   }
@@ -92,8 +90,6 @@ void SmartHandController::menuDisplay()
       break;
     case 4:
       menuBlankTimeout();
-      break;
-    default:
       break;
     }
   }
@@ -174,8 +170,6 @@ void SmartHandController::menuMeridianFlips()
         if (pause) DisplayMessageLX200(SetLX200(":SX97,1#"),false); else DisplayMessageLX200(SetLX200(":SX97,0#"),false);
       }
       break;
-    default:
-      break;
     }
   }
 }
@@ -195,14 +189,12 @@ void SmartHandController::menuSite()
     case 2: menuLatitude(); break;
     case 3: menuLongitude(); break;
     case 4: menuZone(); break;
-    default: break;
     }
   }
 }
 
 void SmartHandController::menuSites()
 {
-  char out[20];
   int val;
 
   if (DisplayMessageLX200(GetSiteLX200(val)))

--- a/addons/St4Serial/SmartHandController/MenuSyncGoto.h
+++ b/addons/St4Serial/SmartHandController/MenuSyncGoto.h
@@ -33,8 +33,6 @@ void SmartHandController::menuSyncGoto(bool sync)
         current_selection_L0 = 0;
       }
       break;
-      default:
-      break;
     }
   }
 }

--- a/addons/St4Serial/SmartHandController/SmartController.cpp
+++ b/addons/St4Serial/SmartHandController/SmartController.cpp
@@ -58,8 +58,8 @@ static unsigned char guiding_bits[] U8X8_PROGMEM = {
 static unsigned char no_tracking_bits[] U8X8_PROGMEM = {
   0x00, 0x00, 0x00, 0x00, 0x38, 0x1c, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x7c, 0x3e, 0x38, 0x1c, 0x00, 0x00 };
 
-static unsigned char tracking_bits[] U8X8_PROGMEM = {
-  0x00, 0x00, 0x02, 0x00, 0x06, 0x00, 0x0e, 0x00, 0x1e, 0x00, 0x3e, 0x00, 0x7e, 0x00, 0xfe, 0x38, 0xfe, 0x44, 0x7e, 0x44, 0x3e, 0x20, 0x1e, 0x10, 0x0e, 0x10, 0x06, 0x00, 0x02, 0x10, 0x00, 0x00 };
+//static unsigned char tracking_bits[] U8X8_PROGMEM = {
+//  0x00, 0x00, 0x02, 0x00, 0x06, 0x00, 0x0e, 0x00, 0x1e, 0x00, 0x3e, 0x00, 0x7e, 0x00, 0xfe, 0x38, 0xfe, 0x44, 0x7e, 0x44, 0x3e, 0x20, 0x1e, 0x10, 0x0e, 0x10, 0x06, 0x00, 0x02, 0x10, 0x00, 0x00 };
 
 static unsigned char tracking_S_bits[] U8X8_PROGMEM = {
   0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x06, 0x00, 0x0e, 0x00, 0x1e, 0x00, 0x3e, 0x00, 0x7e, 0x00, 0xfe, 0x38, 0x7e, 0x04, 0x3e, 0x04, 0x1e, 0x18, 0x0e, 0x20, 0x06, 0x20, 0x02, 0x1c, 0x00, 0x00 };
@@ -412,8 +412,6 @@ void SmartHandController::updateMainDisplay( u8g2_uint_t page)
   u8g2_t *u8g2 = display->getU8g2();
   display->setFont(u8g2_font_helvR12_te);
   u8g2_uint_t line_height = u8g2_GetAscent(u8g2) - u8g2_GetDescent(u8g2) + MY_BORDER_SIZE;
-  u8g2_uint_t step1 = u8g2_GetUTF8Width(u8g2, "44");
-  u8g2_uint_t step2 = u8g2_GetUTF8Width(u8g2, "4") + 1;
 
   // get the status
   telInfo.connected = true;
@@ -448,7 +446,6 @@ void SmartHandController::updateMainDisplay( u8g2_uint_t page)
   do
   {
     u8g2_uint_t x = u8g2_GetDisplayWidth(u8g2);
-    int k = 0;
 
     // wifi status
     if (wifiOn) display->drawXBMP(0, 0, icon_width, icon_height, wifi_bits);
@@ -601,7 +598,7 @@ void SmartHandController::drawReady()
 // Alt Main Menu (double click)
 void SmartHandController::menuSpeedRate()
 {
-  char * string_list_Speed = "0.25x\n0.5x\n1.0x\n2.0x\n4.0x\n8.0x\n20.0x\n48.0x\n0.5 Max\nMax";
+  char string_list_Speed[] = "0.25x\n0.5x\n1.0x\n2.0x\n4.0x\n8.0x\n20.0x\n48.0x\n0.5 Max\nMax";
   current_selection_speed = display->UserInterfaceSelectionList(&buttonPad, "Set Speed", current_selection_speed, string_list_Speed);
   if (current_selection_speed > 0)
   {
@@ -629,7 +626,6 @@ void SmartHandController::menuMain()
         case 5: menuTracking(); break;
         case 6: menuPEC(); break;
         case 7: menuSettings(); break;
-        default: break;
       }
     } else {
       const char *string_list_main_UnParkedL0 = "Goto\n""Sync\n""Align\n""Parking\n""Tracking\n""Settings";
@@ -641,7 +637,6 @@ void SmartHandController::menuMain()
         case 4: menuParking(); break;
         case 5: menuTracking(); break;
         case 6: menuSettings(); break;
-        default: break;
       }
     }
   }
@@ -667,7 +662,6 @@ void SmartHandController::menuParking()
     case 1: DisplayMessageLX200(SetLX200(":hP#"),false); break;
     case 2: DisplayMessageLX200(SetLX200(":hR#"),false); break;
     case 3: DisplayMessageLX200(SetLX200(":hQ#"),false); break;
-    default: break;
     }
   }
 }
@@ -691,9 +685,9 @@ void SmartHandController::menuTracking()
       {
       case 1:
         if (currentstate == Telescope::TRK_ON) {
-          char out[20]=""; if (SetLX200(":Td#")== LX200VALUESET) { DisplayMessage("Tracking", "OFF", 500); currentstate=Telescope::TRK_OFF; } else DisplayMessage("Set State", "Failed", 1000);
+          if (SetLX200(":Td#")== LX200VALUESET) { DisplayMessage("Tracking", "OFF", 500); currentstate=Telescope::TRK_OFF; } else DisplayMessage("Set State", "Failed", 1000);
         } else {
-          char out[20]=""; if (SetLX200(":Te#")== LX200VALUESET) { DisplayMessage("Tracking", "ON", 500); currentstate=Telescope::TRK_ON; } else DisplayMessage("Set State", "Failed", 1000);
+          if (SetLX200(":Te#")== LX200VALUESET) { DisplayMessage("Tracking", "ON", 500); currentstate=Telescope::TRK_ON; } else DisplayMessage("Set State", "Failed", 1000);
         }
       break;
       case 2: DisplayMessageLX200(SetLX200(":TQ#"),false); break;
@@ -719,9 +713,9 @@ void SmartHandController::menuTracking()
       {
       case 1:
         if (currentstate == Telescope::TRK_ON) {
-          char out[20]=""; if (SetLX200(":Td#")== LX200VALUESET) { DisplayMessage("Tracking", "OFF", 500); currentstate=Telescope::TRK_OFF; } else DisplayMessage("Set State", "Failed", 1000);
+          if (SetLX200(":Td#")== LX200VALUESET) { DisplayMessage("Tracking", "OFF", 500); currentstate=Telescope::TRK_OFF; } else DisplayMessage("Set State", "Failed", 1000);
         } else {
-          char out[20]=""; if (SetLX200(":Te#")== LX200VALUESET) { DisplayMessage("Tracking", "ON", 500); currentstate=Telescope::TRK_ON; } else DisplayMessage("Set State", "Failed", 1000);
+          if (SetLX200(":Te#")== LX200VALUESET) { DisplayMessage("Tracking", "ON", 500); currentstate=Telescope::TRK_ON; } else DisplayMessage("Set State", "Failed", 1000);
         }
       break;
       case 2:  DisplayMessageLX200(SetLX200(":TQ#"),false); break;

--- a/addons/St4Serial/SmartHandController/St4SerialSlave.h
+++ b/addons/St4Serial/SmartHandController/St4SerialSlave.h
@@ -23,6 +23,7 @@ all others (Teensy3.x, etc.) at 2mS/byte (500 Bps.)
 */
 
 #include "Stream.h"
+#include "Config.h"
 
 #if !defined(ST4RAw) && !defined(ST4DEs) && !defined(ST4DEn) && !defined(ST4RAe)
   #warning "ST4 interface pins aren't defined, using defaults."
@@ -67,4 +68,3 @@ class Sst4 : public Stream
 };
 
 extern Sst4 SerialST4;
-

--- a/addons/St4Serial/SmartHandController/Telescope.cpp
+++ b/addons/St4Serial/SmartHandController/Telescope.cpp
@@ -166,7 +166,7 @@ Telescope::Errors Telescope::getError()
     default:
       return ERR_NONE;
     }
-  }
+  } else return ERR_NONE;
 }
 
 bool Telescope::addStar()
@@ -191,5 +191,3 @@ bool Telescope::addStar()
     return false;
   }
 }
-
-


### PR DESCRIPTION
Reinstating the previous fixes, minus the ones that caused a crash. 

Still some warnings in the u8g code, but they are harder to fix since they are many levels of indirection of calls.