### PR TITLE
few changes to address  "SHC development ideas" issue

### DIFF
--- a/addons/St4Serial/SmartHandController/MenuSettings.h
+++ b/addons/St4Serial/SmartHandController/MenuSettings.h
@@ -6,7 +6,7 @@ void SmartHandController::menuSettings()
   while (current_selection_L1 != 0)
   {
     if (telInfo.isMountGEM()) {
-      const char *string_list_SettingsL1 = "Date/Time\n""Display\n""Buzzer\n""Meridian Flp\n""Configuration\n""Site";
+      const char *string_list_SettingsL1 = "Date/Time\n""Display\n""Buzzer\n""Meridian Flip\n""Configuration\n""Site\n""Firmware Ver";
       current_selection_L1 = display->UserInterfaceSelectionList(&buttonPad, "Settings", current_selection_L1, string_list_SettingsL1);
       switch (current_selection_L1)
       {
@@ -16,6 +16,7 @@ void SmartHandController::menuSettings()
       case 4: menuMeridianFlips(); break;
       case 5: menuMount(); break;
       case 6: menuSite(); break;
+      case 7: menuFirmware(); break;
       }
     } else {
       const char *string_list_SettingsL1 = "Date/Time\n""Display\n""Buzzer\n""Configuration\n""Site";
@@ -275,5 +276,22 @@ void SmartHandController::menuZone()
         DisplayMessageLX200(SetLX200(out),false);
       }
     }
+  }
+}
+
+void SmartHandController::menuFirmware()
+{
+  char out[20];
+  
+  sprintf(out,"SHC %s", _version);
+  DisplayMessage(out, __DATE__, 3000);
+
+  char temp1[20];
+  char temp2[20];
+  if ( (DisplayMessageLX200(GetLX200(":GVN#", temp1)))&&(DisplayMessageLX200(GetLX200(":GVD#", temp2))) )
+  { for (char* p = temp1; p = strchr(p, '#'); ++p) { *p = 0;} 
+    for (char* p = temp2; p = strchr(p, '#'); ++p) { *p = 0;} 
+    sprintf(out,"OnStep %s",temp1);
+    DisplayMessage(out, temp2, 3000);
   }
 }

--- a/addons/St4Serial/SmartHandController/SmartController.cpp
+++ b/addons/St4Serial/SmartHandController/SmartController.cpp
@@ -450,6 +450,11 @@ void SmartHandController::updateMainDisplay( u8g2_uint_t page)
     // wifi status
     if (wifiOn) display->drawXBMP(0, 0, icon_width, icon_height, wifi_bits);
 
+    // last selected guide rate
+      char *string_Speed[10] = {"0.25x","0.5x","1.0x","2.0x","4.0x","8.0x","20.0x","48.0x","0.5 Max","Max"};
+      if ((current_selection_speed>0)&&(current_selection_speed<=10))
+        u8g2_DrawUTF8(u8g2, 0, icon_height, string_Speed[current_selection_speed-1]); 
+
     // OnStep status
     if (telInfo.hasTelStatus) {
       Telescope::ParkState curP = telInfo.getParkState();
@@ -659,9 +664,14 @@ void SmartHandController::menuParking()
     current_selection_L1 = display->UserInterfaceSelectionList(&buttonPad, "Parking", current_selection_L1, string_list_SettingsL1);
     switch (current_selection_L1)
     {
-    case 1: DisplayMessageLX200(SetLX200(":hP#"),false); break;
-    case 2: DisplayMessageLX200(SetLX200(":hR#"),false); break;
-    case 3: DisplayMessageLX200(SetLX200(":hQ#"),false); break;
+    case 1: if (SetLX200(":hP#")== LX200VALUESET) DisplayMessage("Parking", "scope", 500); else DisplayMessage("Park", "Failed", 1000); break;
+    case 2: if (SetLX200(":hR#")== LX200VALUESET) DisplayMessage("Un-Parking", "scope", 500); else DisplayMessage("Un-Park", "Failed", 1000); break;
+    case 3: boolean SetP=false; 
+            if (display->UserInterfaceInputValueBoolean(&buttonPad, "Set-Park?", &SetP)) 
+             if (SetP){
+              if (SetLX200(":hQ#")== LX200VALUESET) DisplayMessage("Set-Park", "OK", 500); else DisplayMessage("Set-Park", "Failed", 1000); 
+             } else DisplayMessage("Set-Park", "Canceled", 500);
+            break;           
     }
   }
 }

--- a/addons/St4Serial/SmartHandController/SmartController.h
+++ b/addons/St4Serial/SmartHandController/SmartController.h
@@ -106,6 +106,7 @@ private:
   void menuOverhead();
   void menuMeridianE();
   void menuMeridianW();
+  void menuFirmware();
 
   void DisplayMessage(const char* txt1, const char* txt2 = NULL, int duration = 0);
   void DisplayLongMessage(const char* txt1, const char* txt2 = NULL, const char* txt3 = NULL, const char* txt4 = NULL, int duration = 0);


### PR DESCRIPTION
1. Show active guide rate - perhaps top line at the left
The last selected guide rate is shown on the top line now. However if the guide rate is changed via other source than SHC it does not get updated - SHC does not read the guide rate from OnStep via LX200 command. This is not an issue for me but it can certainly be updated later on.

2. Change "Value set" messages to meaningful messages like "Unparked" e.t.c.
Parking/Unparking messages added. 

4. Set Park, Return/Reset Home - ask for confirmation (to prevent accidental triggering of model clear)
Confirmation for Set-Park added.

9. Display OnStep & SHC firmware version
Added new menu under settings that shows SHC Version / Date & Onstep Version / date.