### PR TITLE
Support for DS18B20

### DIFF
--- a/Config.MiniPCB.h
+++ b/Config.MiniPCB.h
@@ -83,6 +83,10 @@
 // Sound state at startup, default=_ON.
 #define DEFAULT_SOUND_ON
 
+// External temparature monitoring via DS1820 on ONE WIRE interface, default _OFF
+#define TEMPERATURE_DS1820_OFF                                       // enable DS1820 sensor
+#define DS1820_ONE_WIRE_BUS 30                                       // GPIO used for ONE WIRE bus 
+
 // Optionally adjust tracking rate to compensate for atmospheric refraction, default=_OFF
 // can be turned on/off with the :Tr# and :Tn# commands regardless of this setting
 #define TRACK_REFRACTION_RATE_DEFAULT_OFF

--- a/src/lib/Weather.h
+++ b/src/lib/Weather.h
@@ -8,6 +8,12 @@
 Adafruit_BME280 bme;
 #endif
 
+#ifdef TEMPERATURE_DS1820_ON
+#include <OneWire.h>                    // added via built in Arduino IDE library manager
+#include <DallasTemperature.h>          // added via built in Arduino IDE library manager
+OneWire oneWire(DS1820_ONE_WIRE_BUS);
+DallasTemperature DS18B20(&oneWire);
+#endif
 class weather {
   public:
     void init() {
@@ -21,6 +27,13 @@ class weather {
 #ifdef ESP32
       HAL_Wire.end();
 #endif
+#endif
+#ifdef TEMPERATURE_DS1820_ON
+      _disabled=false;
+      if (!_disabled) {
+        DS18B20.requestTemperatures(); 
+        _t=DS18B20.getTempCByIndex(0);
+      }
 #endif
     }
 
@@ -38,6 +51,15 @@ class weather {
 #ifdef ESP32
         if ((phase==10) || (phase==30) || (phase==50)) HAL_Wire.end();  
 #endif
+        phase++; if (phase==60) phase=0;
+      }
+#endif
+#ifdef TEMPERATURE_DS1820_ON
+      if (!_disabled) {
+        static int phase=0;
+        if (phase==10) { DS18B20.requestTemperatures(); _t=DS18B20.getTempCByIndex(0); } 
+        if (phase==30) ;    //nothing to do here
+        if (phase==50) ;    //nothing to do here
         phase++; if (phase==60) phase=0;
       }
 #endif


### PR DESCRIPTION
Added support for DS18B20 temperature sensor connected to GPIO on miniPCB with Teensy 3.2.
Should work for other boards as well - the one wire GPIO pins needs to be remapped to appropriate pin though.