### PR TITLE
Faster end of slew, and ability to change maximum number of stars

### DIFF
--- a/MoveTo.ino
+++ b/MoveTo.ino
@@ -282,8 +282,8 @@ void moveTo() {
           SiderealClockSetInterval(siderealInterval);
           setDeltaTrackingRate();
           
-          // allow 10 seconds for synchronization of coordinates after goto ends
-          if (trackingState==TrackingSidereal) trackingSyncSeconds=15;
+          // allow 5 seconds for synchronization of coordinates after goto ends
+          if (trackingState==TrackingSidereal) trackingSyncSeconds=5;
         }
       }
     }

--- a/Validate.h
+++ b/Validate.h
@@ -155,7 +155,7 @@
 
 // figure out how many align star are allowed for the configuration
 #if defined(MAX_NUM_ALIGN_STARS)
-  #if MAX_NUM_ALIGN_STARS > 9 || MAX_NUM_ALIGN_STARS < 6
+  #if MAX_NUM_ALIGN_STARS > '9' || MAX_NUM_ALIGN_STARS < '6'
     #error MAX_NUM_ALIGN_STARS must be 6 to 9
   #else
     #warning MAX_NUM_ALIGN_STARS explicitly defined in Config file. Controller may be slow for a few minutes after last star align.

--- a/Validate.h
+++ b/Validate.h
@@ -154,21 +154,25 @@
 #endif
 
 // figure out how many align star are allowed for the configuration
-#if defined(HAL_FAST_PROCESSOR)
-  #if defined(MOUNT_TYPE_GEM)
-    #define MAX_NUM_ALIGN_STARS '9'
-  #elif defined(MOUNT_TYPE_FORK)
-    #define MAX_NUM_ALIGN_STARS '9'
-  #elif defined(MOUNT_TYPE_ALTAZM)
-    #define MAX_NUM_ALIGN_STARS '9'
-  #endif
+#if defined(MAX_NUM_ALIGN_STARS)
+  #warning MAX_NUM_ALIGN_STARS explicitly defined in Config.x.h file. Controller may be slow after last star align.
 #else
-  #if defined(MOUNT_TYPE_GEM)
-    #define MAX_NUM_ALIGN_STARS '6'
-  #elif defined(MOUNT_TYPE_FORK)
-    #define MAX_NUM_ALIGN_STARS '6'
-  #elif defined(MOUNT_TYPE_ALTAZM)
-    #define MAX_NUM_ALIGN_STARS '6'
+  #if defined(HAL_FAST_PROCESSOR)
+    #if defined(MOUNT_TYPE_GEM)
+      #define MAX_NUM_ALIGN_STARS '9'
+    #elif defined(MOUNT_TYPE_FORK)
+      #define MAX_NUM_ALIGN_STARS '9'
+    #elif defined(MOUNT_TYPE_ALTAZM)
+      #define MAX_NUM_ALIGN_STARS '9'
+    #endif
+  #else
+    #if defined(MOUNT_TYPE_GEM)
+      #define MAX_NUM_ALIGN_STARS '6'
+    #elif defined(MOUNT_TYPE_FORK)
+      #define MAX_NUM_ALIGN_STARS '6'
+    #elif defined(MOUNT_TYPE_ALTAZM)
+      #define MAX_NUM_ALIGN_STARS '6'
+    #endif
   #endif
 #endif
 

--- a/Validate.h
+++ b/Validate.h
@@ -155,7 +155,11 @@
 
 // figure out how many align star are allowed for the configuration
 #if defined(MAX_NUM_ALIGN_STARS)
-  #warning MAX_NUM_ALIGN_STARS explicitly defined in Config.x.h file. Controller may be slow after last star align.
+  #if MAX_NUM_ALIGN_STARS > 9 || MAX_NUM_ALIGN_STARS < 6
+    #error MAX_NUM_ALIGN_STARS must be 6 to 9
+  #else
+    #warning MAX_NUM_ALIGN_STARS explicitly defined in Config file. Controller may be slow for a few minutes after last star align.
+  #endif
 #else
   #if defined(HAL_FAST_PROCESSOR)
     #if defined(MOUNT_TYPE_GEM)


### PR DESCRIPTION
End of slew is very slow with the 15 seconds. This was put in after KStars/Ekos users complained that precision slews would never end. I changed the 15 seconds to 5 seconds and tested precision slews, and they work well, but with a much less annoying wait.

Also, if MAX_NUM_ALIGN_STARS is defined in Config.x.h, that value will take precedence, with a warning displayed to inform the user that this may slow down alignment. This allows adventurous users to increase the number of stars if needed. 