### PR TITLE
Add LIMIT_SENSE_STATE to allow either LOW or HIGH states

### DIFF
--- a/Config.Classic.h
+++ b/Config.Classic.h
@@ -65,6 +65,8 @@
 
 // switch close (to ground) on pin 3 for optional limit sense (stops gotos and/or tracking), default=_OFF
 #define LIMIT_SENSE_OFF
+// Change this to HIGH if your switch is on when tripped
+#define LIMIT_SENSE_STATE LOW
 
 // Light status LED by sink to ground (pin 9) and source +5V (pin 8), default=_ON
 // _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash

--- a/Config.MaxESP2.h
+++ b/Config.MaxESP2.h
@@ -77,6 +77,8 @@
 
 // Switch close (to ground) on Aux7 (Pin 39) for optional limit sense (stops gotos and/or tracking), Built-in pullup resistors are not available. Default=_OFF.  Choose only one feature on Aux7.
 #define LIMIT_SENSE_OFF
+// Change this to HIGH if your switch is on when tripped
+#define LIMIT_SENSE_STATE LOW
 
 // Light status LED by sink to ground Aux8 (Pin 25), default=_OFF. Choose only one feature on Aux8.
 // _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash.

--- a/Config.MaxPCB.h
+++ b/Config.MaxPCB.h
@@ -67,6 +67,8 @@
 
 #define LIMIT_SENSE_OFF
 // Switch close (to ground) on Aux7 (Pin 4) for optional limit sense (stops gotos and/or tracking), default=_OFF  Choose only one feature on Aux7.
+// Change this to HIGH if your switch is on when tripped
+#define LIMIT_SENSE_STATE LOW
 
 // Light status LED by sink to ground (Pin 19), default=_ON.
 // _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash.

--- a/Config.MiniPCB.h
+++ b/Config.MiniPCB.h
@@ -67,6 +67,8 @@
 
 #define LIMIT_SENSE_OFF
 // Switch close (to ground) on Aux3 (Pin 4) for optional limit sense (stops gotos and/or tracking), default=_OFF  Choose only one feature on Aux4.
+// Change this to HIGH if your switch is on when tripped
+#define LIMIT_SENSE_STATE LOW
 
 // Light status LED by sink to ground (Pin 19), default=_ON.
 // _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash

--- a/Config.Ramps14.h
+++ b/Config.Ramps14.h
@@ -70,6 +70,8 @@
 
 // Switch close (to ground) on Pin 3 for optional limit sense (stops gotos and/or tracking), default=_OFF
 #define LIMIT_SENSE_OFF
+// Change this to HIGH if your switch is on when tripped
+#define LIMIT_SENSE_STATE LOW
 
 // Light status LED by sink to ground (Pin 11), default=_ON.
 // _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash

--- a/Config.STM32.h
+++ b/Config.STM32.h
@@ -66,6 +66,8 @@
 
 // Switch close (to ground) for optional limit sense (stops gotos and/or tracking), default=_OFF
 #define LIMIT_SENSE_OFF
+// Change this to HIGH if your switch is on when tripped
+#define LIMIT_SENSE_STATE LOW
 
 // Light status LED by sink to ground, default=_ON.
 // _ON and OnStep keeps this illuminated to indicate that the controller is active.  When sidereal tracking this LED will rapidly flash

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -375,11 +375,11 @@ void loop2() {
     // support for limit switch(es)
 #ifdef LIMIT_SENSE_ON
     byte limit_1st = digitalRead(LimitPin);
-    if (limit_1st == LOW) {
+    if (limit_1st == LIMIT_SENSE_STATE) {
       // Wait for a short while, then read again
       delayMicroseconds(50);
       byte limit_2nd = digitalRead(LimitPin);
-      if (limit_2nd == LOW) {
+      if (limit_2nd == LIMIT_SENSE_STATE) {
         // It is still low, there must be a problem
         lastError=ERR_LIMIT_SENSE;
         stopLimit();

--- a/Validate.h
+++ b/Validate.h
@@ -528,6 +528,16 @@
   #define AXIS2_STEP_GOTO 1
 #endif
 
+// Limit sense state
+#ifdef LIMIT_SENSE_STATE
+  #if LIMIT_SENSE_STATE != LOW && LIMIT_SENSE_STATE != HIGH
+    #error "LIMIT_SENSE_STATE must be either HIGH or LOW"
+  #endif
+#else
+  // Default to low
+  #define LIMIT_SENSE_STATE LOW
+#endif
+
 // -----------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------
 // misc. validation


### PR DESCRIPTION
This changes allows switches to be either of the normally open (NO) type or the normally closed (NC) variety.

Backward compatible with existing config files, i.e. default to LOW.