### PR TITLE
Shift, f & F buttons not canceling the slew

### DIFF
--- a/addons/St4Serial/SmartHandController/Pad.cpp
+++ b/addons/St4Serial/SmartHandController/Pad.cpp
@@ -32,6 +32,13 @@ bool Pad::anyPressed()
   return false;
 }
 
+bool Pad::nsewPressed()
+{
+  if (n.isDown() || s.isDown() || e.isDown() || w.isDown()) return true;
+  if (n.wasPressed(true) || s.wasPressed(true) || e.wasPressed(true) || w.wasPressed(true)) return true;
+  return false;
+}
+
 void Pad::waitForPress() {
   for (;;) { tickButtons(); delay(5); if (anyPressed()) break; }
 }

--- a/addons/St4Serial/SmartHandController/Pad.h
+++ b/addons/St4Serial/SmartHandController/Pad.h
@@ -9,6 +9,7 @@ public:
 
   void tickButtons();
   bool anyPressed();
+  bool nsewPressed();  
   void waitForPress();
   void clearAllPressed();
 

--- a/addons/St4Serial/SmartHandController/SmartController.cpp
+++ b/addons/St4Serial/SmartHandController/SmartController.cpp
@@ -418,12 +418,13 @@ void SmartHandController::update()
   // is a goto happening?
   if (telInfo.connected && (telInfo.getTrackingState() == Telescope::TRK_SLEWING || telInfo.getParkState() == Telescope::PRK_PARKING))
   {
-    if (buttonPad.anyPressed()) {
+    if (buttonPad.nsewPressed()) {
       Ser.print(":Q#"); Ser.flush();
       if (telInfo.align != Telescope::ALI_OFF) telInfo.align = static_cast<Telescope::AlignState>(telInfo.align - 1); // try another align star?
       time_last_action = millis();
       display->sleepOff();
       buttonPad.clearAllPressed();
+      DisplayMessage("Slew to target", "canceled!", 1000);
       return;
     }
   } else


### PR DESCRIPTION
Shift, f & F butons do not cancel the slew in progress. The behaviour of guiding keys (N, S, E, W) has not changed but a message is displayed that the slew was canceled.