### PR TITLE
Enable alternate 0x76 BME280 address in the Config.h file

### DIFF
--- a/src/lib/Weather.h
+++ b/src/lib/Weather.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#if WEATHER == BME280 || WEATHER == BME280SPI
+#if WEATHER == BME280 || WEATHER == BME280SPI || WEATHER == BME280_0x76
   #include <Adafruit_BME280.h>            // https://github.com/adafruit/Adafruit_BME280_Library and https://github.com/adafruit/Adafruit_Sensor
-  #if WEATHER == BME280
+  #if WEATHER == BME280 || WEATHER == BME280_0x76
     Adafruit_BME280 bme;
   #elif WEATHER == BME280SPI
     Adafruit_BME280 bme(BME280_CS_PIN);                                   // hardware SPI
@@ -26,9 +26,11 @@ class weather {
 #if TELESCOPE_TEMPERATURE == DS1820
       _disabled=false;
 #endif
-#if WEATHER == BME280 || WEATHER == BME280SPI
+#if WEATHER == BME280 || WEATHER == BME280SPI || WEATHER == BME280_0x76
       #if WEATHER == BME280
         if (bme.begin(&HAL_Wire)) _disabled=false;
+      #elif WEATHER == BME280_0x76
+        if (bme.begin(0x76,&HAL_Wire)) _disabled=false;
       #else
         if (bme.begin()) _disabled=false;
       #endif
@@ -41,11 +43,11 @@ class weather {
     // designed for a 1s polling interval to refresh readings once a minute
     void poll() {
 
-#if WEATHER == BME280 || WEATHER == BME280SPI || TELESCOPE_TEMPERATURE == DS1820
+#if WEATHER == BME280 || WEATHER == BME280SPI || WEATHER == BME280_0x76 || TELESCOPE_TEMPERATURE == DS1820
       if (!_disabled) {
         static int phase=0;
 
-  #if WEATHER == BME280 || WEATHER == BME280SPI
+  #if WEATHER == BME280 || WEATHER == BME280SPI || WEATHER == BME280_0x76
     #ifdef ESP32
         if ((phase == 10) || (phase == 30) || (phase == 50)) HAL_Wire.begin();
     #endif
@@ -66,7 +68,7 @@ class weather {
         if (phase == 70) {
           DS18B20.requestTemperatures();
           _tt=DS18B20.getTempCByIndex(0);
-    #if WEATHER != BME280 && WEATHER != BME280SPI
+    #if WEATHER != BME280 && WEATHER != BME280SPI && WEATHER != BME280_0x76
           _t=_tt;
     #endif
         }


### PR DESCRIPTION
For those with 0x76 addressed BME280 modules without having to cut wires/solder their boards or make library file changes