### PR TITLE
Fix for absolute focuser positioning :FSn# command

### DIFF
--- a/Command.ino
+++ b/Command.ino
@@ -331,7 +331,7 @@ void processCommands() {
 #endif
 
         // check for commands that shouldn't have a parameter
-        boolean badcmd = false; if (strchr("TpIMtuQFS1234+-GZHh",command[1]) && parameter[0] != 0) badcmd = true;
+        boolean badcmd = false; if (strchr("TpIMtuQF1234+-GZHh",command[1]) && parameter[0] != 0) badcmd = true;
 
         if (foc != NULL && !badcmd) {
 


### PR DESCRIPTION
Uppercase :FSn# command for Absolute Focuser setTarget in Microns was failing with a badCmd=true as :FS was still not expected to have a parameter during this check