### PR TITLE
Changes to add Focuser backlash and TC deadband parameter setting

### DIFF
--- a/addons/SmartHandController/LX200.cpp
+++ b/addons/SmartHandController/LX200.cpp
@@ -57,7 +57,7 @@ bool processCommand(char* command, char* response, unsigned long timeOutMs) {
     }
     if ((command[1]=='F') || (command[1]=='f')) {
       if (strchr("+-QZHhFS1234",command[2])) noResponse=true;
-      if (strchr("Apc",command[2]) || (strchr("C",command[2])&&command[3]!='#')) shortResponse=true;
+      if (strchr("Apc",command[2]) || (strchr("B",command[2])&&command[3]!='#') || (strchr("C",command[2])&&command[3]!='#') || (strchr("D",command[2])&&command[3]!='#')) shortResponse=true;
     }
     if (command[1] == 'M') {
       if (strchr("ewnsg", command[2])) noResponse = true;
@@ -438,6 +438,44 @@ LX200RETURN writeFocTCCoefLX200(const uint8_t &foc, const float &tccoef)
   char text[20];
   if (foc == 1) SetLX200(":FA1#"); else SetLX200(":FA2#");
   sprintf(text, ":FC%d#", (signed int)tccoef);
+  return SetLX200(text);
+}
+LX200RETURN readFocBacklashLX200(const uint8_t &foc, float &backlash)
+{
+  char out[20];
+  if (foc == 1) SetLX200(":FA1#"); else SetLX200(":FA2#");
+  LX200RETURN ok = GetLX200(":FB#", out);
+  if (ok == LX200VALUEGET)
+  {
+    backlash = (float)strtol(&out[0], NULL, 10);
+  }
+  return ok;
+}
+
+LX200RETURN writeFocBacklashLX200(const uint8_t &foc, const float &backlash)
+{
+  char text[20];
+  if (foc == 1) SetLX200(":FA1#"); else SetLX200(":FA2#");
+  sprintf(text, ":FB%d#", (signed int)backlash);
+  return SetLX200(text);
+}
+LX200RETURN readFocTCDeadbandLX200(const uint8_t &foc, float &tcdeadband)
+{
+  char out[20];
+  if (foc == 1) SetLX200(":FA1#"); else SetLX200(":FA2#");
+  LX200RETURN ok = GetLX200(":FD#", out);
+  if (ok == LX200VALUEGET)
+  {
+    tcdeadband = (float)strtol(&out[0], NULL, 10);
+  }
+  return ok;
+}
+
+LX200RETURN writeFocTCDeadbandLX200(const uint8_t &foc, const float &tcdeadband)
+{
+  char text[20];
+  if (foc == 1) SetLX200(":FA1#"); else SetLX200(":FA2#");
+  sprintf(text, ":FD%d#", (signed int)tcdeadband);
   return SetLX200(text);
 }
 

--- a/addons/SmartHandController/LX200.h
+++ b/addons/SmartHandController/LX200.h
@@ -39,6 +39,10 @@ LX200RETURN readBacklashLX200(const uint8_t &axis, float &backlash);
 LX200RETURN writeBacklashLX200(const uint8_t &axis, const float &backlash);
 LX200RETURN readFocTCCoefLX200(const uint8_t &foc, float &tccoef);
 LX200RETURN writeFocTCCoefLX200(const uint8_t &foc, const float &tccoef);
+LX200RETURN readFocBacklashLX200(const uint8_t &foc, float &tccoef);
+LX200RETURN writeFocBacklashLX200(const uint8_t &foc, const float &tccoef);
+LX200RETURN readFocTCDeadbandLX200(const uint8_t &foc, float &tccoef);
+LX200RETURN writeFocTCDeadbandLX200(const uint8_t &foc, const float &tccoef);
 
 boolean hmsToDouble(double *f, char *hms);
 boolean dmsToDouble(double *f, char *dms, boolean sign_present, boolean highPrecision);

--- a/addons/SmartHandController/MenuSettings.h
+++ b/addons/SmartHandController/MenuSettings.h
@@ -298,7 +298,7 @@ void SmartHandController::menuFocuser1()
   current_selection_L2 = 1;
   while (current_selection_L2 != 0)
   {
-    const char *string_list_SiteL2 = L_FOC_RET_HOME "\n" L_FOC_AT_HOME "\n" L_FOC_TC "\n" L_FOC_TC_COEF;
+    const char *string_list_SiteL2 = L_FOC_RET_HOME "\n" L_FOC_AT_HOME "\n" L_FOC_BACKLASH "\n" L_FOC_TC "\n" L_FOC_TC_COEF "\n" L_FOC_TC_DEADBAND;
     
     if (telInfo.hasFocuser2())
       current_selection_L2 = display->UserInterfaceSelectionList(&buttonPad, L_FOCUSER " 1", current_selection_L2, string_list_SiteL2);
@@ -317,6 +317,9 @@ void SmartHandController::menuFocuser1()
       }
       break;
     case 3:
+      menuSetFocBacklash(foc);
+      break;
+    case 4:
       if (display->UserInterfaceInputValueBoolean(&buttonPad, L_FOC_TC, &isOk)) {
         if (isOk)
         {
@@ -330,8 +333,11 @@ void SmartHandController::menuFocuser1()
         }
       }
       break;
-    case 4:
+    case 5:
       menuSetFocTCCoef(foc);
+      break;
+    case 6:
+      menuSetFocTCDeadband(foc);
       break;
     }
   }
@@ -342,7 +348,7 @@ void SmartHandController::menuFocuser2()
   current_selection_L2 = 1;
   while (current_selection_L2 != 0)
   {
-    const char *string_list_SiteL2 = L_FOC_RET_HOME "\n" L_FOC_AT_HOME "\n" L_FOC_TC "\n" L_FOC_TC_COEF;
+    const char *string_list_SiteL2 = L_FOC_RET_HOME "\n" L_FOC_AT_HOME "\n" L_FOC_BACKLASH "\n" L_FOC_TC "\n" L_FOC_TC_COEF "\n" L_FOC_TC_DEADBAND;
     current_selection_L2 = display->UserInterfaceSelectionList(&buttonPad, L_FOCUSER " 2", current_selection_L2, string_list_SiteL2);
     bool isOk=false;
     uint8_t foc = 2;
@@ -357,6 +363,9 @@ void SmartHandController::menuFocuser2()
       }
     break;
     case 3:
+      menuSetFocBacklash(foc);
+      break;
+    case 4:
       if (display->UserInterfaceInputValueBoolean(&buttonPad, L_FOC_TC, &isOk)) {
         if (isOk)
         {
@@ -370,11 +379,30 @@ void SmartHandController::menuFocuser2()
         }
       }
       break;
-    case 4:
+    case 5:
       menuSetFocTCCoef(foc);
+      break;
+    case 6:
+      menuSetFocTCDeadband(foc);
       break;
     }
   }
+}
+
+bool SmartHandController::menuSetFocBacklash(uint8_t &foc)
+{
+  float backlash;
+  if (!DisplayMessageLX200(readFocBacklashLX200(foc, backlash))) return false;
+  char text[20];
+  if (foc == 1 && !telInfo.hasFocuser2())
+    sprintf(text, "Focuser " L_FOC_BACKLASH);
+  else
+    sprintf(text, "Foc.%u " L_FOC_BACKLASH, foc);
+  if (display->UserInterfaceInputValueFloat(&buttonPad, text, "", &backlash, 0, 999, 3, 0, " " L_FOC_BL_UNITS))
+  {
+    return DisplayMessageLX200(writeFocBacklashLX200(foc, backlash),false);
+  }
+  return true;
 }
 
 bool SmartHandController::menuSetFocTCCoef(uint8_t &foc)
@@ -389,6 +417,22 @@ bool SmartHandController::menuSetFocTCCoef(uint8_t &foc)
   if (display->UserInterfaceInputValueFloat(&buttonPad, text, "", &tccoef, -999, 999, 4, 0, " " L_MICRON_PER_C))
   {
     return DisplayMessageLX200(writeFocTCCoefLX200(foc, tccoef),false);
+  }
+  return true;
+}
+
+bool SmartHandController::menuSetFocTCDeadband(uint8_t &foc)
+{
+  float deadband;
+  if (!DisplayMessageLX200(readFocTCDeadbandLX200(foc, deadband))) return false;
+  char text[20];
+  if (foc == 1 && !telInfo.hasFocuser2())
+    sprintf(text, "Focuser " L_FOC_TC_DEADBAND);
+  else
+    sprintf(text, "Foc.%u " L_FOC_TC_DEADBAND, foc);
+  if (display->UserInterfaceInputValueFloat(&buttonPad, text, "", &deadband, 1, 999, 3, 0, " " L_FOC_TC_DB_UNITS))
+  {
+    return DisplayMessageLX200(writeFocTCDeadbandLX200(foc, deadband),false);
   }
   return true;
 }

--- a/addons/SmartHandController/SmartController.h
+++ b/addons/SmartHandController/SmartController.h
@@ -131,6 +131,8 @@ private:
   void menuFocuser1();
   void menuFocuser2();
   bool menuSetFocTCCoef(uint8_t &foc);
+  bool menuSetFocBacklash(uint8_t &foc);
+  bool menuSetFocTCDeadband(uint8_t &foc);
   void menuRotator();
   void menuLatitude();
   void menuLongitude();

--- a/addons/SmartHandController/Strings_en.h
+++ b/addons/SmartHandController/Strings_en.h
@@ -224,6 +224,10 @@
 #define L_FOC_AT_HALF "At Half Trvl?"
 #define L_FOC_TC "Temp. Comp?"
 #define L_FOC_TC_COEF "TC Coef."
+#define L_FOC_TC_DEADBAND "TC Deadband"
+#define L_FOC_TC_DB_UNITS "micron(s)"
+#define L_FOC_BACKLASH "Backlash"
+#define L_FOC_BL_UNITS "micron(s)"
 
 // rotator
 #define L_ROT_RET_HOME "Return Home"


### PR DESCRIPTION
These additions are almost identical to my last set of changes to add focuser TC coefficient parameter setting. The range for backlash is 0 (no backlash) to 999 (ridiculously large backlash) and the range for TC deadband is 1 (should never be 0) to 999 (another ridiculously large number). These values are in microns, but stored by the OnStep controller as steps through conversion using steps_per_micron on the way in and out.