### PR TITLE
powerDownActive is purely virtual/not implemented for DC focuser clas…

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -181,7 +181,7 @@
 #define AXIS4_DRIVER_IRUN             OFF //    OFF, n, (mA.) Current tracking, appropriate for stepper/driver/etc.   "       Option
 #define AXIS4_DRIVER_POWER_DOWN       OFF //    OFF, ON Powers off the motor at stand-still.                                  Option
 #define AXIS4_DRIVER_REVERSE          OFF //    OFF, ON Reverses movement direction, or reverse wiring instead to correct.    Option
-#define AXIS4_DRIVER_DC_MODE          OFF //    OFF, DRV8825 for pwm dc motor control on stepper driver outputs.              Option
+#define AXIS4_DRIVER_DC_MODE          OFF //    OFF, ON for pwm dc motor control on stepper driver outputs.                   Option
 
 #define AXIS4_LIMIT_MIN_RATE           50 //     50, n. Where n=1..1000 (um/s.) Minimum microns/second. In DC mode, min pwr.  Adjust
 #define AXIS4_LIMIT_MIN                 0 //      0, n. Where n=0..500 (millimeters.) Minimum allowed position.               Adjust

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -372,9 +372,8 @@ void setup() {
     tmcAxis4.setup(AXIS4_DRIVER_INTPOL,AXIS4_DRIVER_DECAY_MODE,AXIS4_DRIVER_CODE,axis4Settings.IRUN,axis4SettingsEx.IHOLD);
   #endif
 
-  #if AXIS4_DRIVER_DC_MODE == OFF
-    foc1.powerDownActive(AXIS4_DRIVER_POWER_DOWN == ON, AXIS4_DRIVER_POWER_DOWN == STARTUP);
-  #endif
+
+  foc1.powerDownActive(AXIS4_DRIVER_POWER_DOWN == ON, AXIS4_DRIVER_POWER_DOWN == STARTUP);
 #endif
 
 #if FOCUSER2 == ON

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -372,7 +372,9 @@ void setup() {
     tmcAxis4.setup(AXIS4_DRIVER_INTPOL,AXIS4_DRIVER_DECAY_MODE,AXIS4_DRIVER_CODE,axis4Settings.IRUN,axis4SettingsEx.IHOLD);
   #endif
 
-  foc1.powerDownActive(AXIS4_DRIVER_POWER_DOWN == ON, AXIS4_DRIVER_POWER_DOWN == STARTUP);
+  #if AXIS4_DRIVER_DC_MODE == OFF
+    foc1.powerDownActive(AXIS4_DRIVER_POWER_DOWN == ON, AXIS4_DRIVER_POWER_DOWN == STARTUP);
+  #endif
 #endif
 
 #if FOCUSER2 == ON

--- a/OnStep.ino
+++ b/OnStep.ino
@@ -372,7 +372,6 @@ void setup() {
     tmcAxis4.setup(AXIS4_DRIVER_INTPOL,AXIS4_DRIVER_DECAY_MODE,AXIS4_DRIVER_CODE,axis4Settings.IRUN,axis4SettingsEx.IHOLD);
   #endif
 
-
   foc1.powerDownActive(AXIS4_DRIVER_POWER_DOWN == ON, AXIS4_DRIVER_POWER_DOWN == STARTUP);
 #endif
 

--- a/src/lib/Focuser.h
+++ b/src/lib/Focuser.h
@@ -66,7 +66,7 @@ class focuser {
     virtual void setDisableState(bool disableState) { }
 
     // allows enabling/disabling stepper driver
-    virtual void powerDownActive(bool active) { }
+    virtual void powerDownActive(bool active, bool startupOnly) { }
 
     // set movement rate in microns/second, from minRate to 1000
     virtual void setMoveRate(double rate) { }

--- a/src/lib/FocuserDC.h
+++ b/src/lib/FocuserDC.h
@@ -51,6 +51,7 @@ class focuserDC : public focuser  {
     byte getDcPower() { return powerFor1mmSec; }
     bool setPhase1() { phase1=true; return true; }
     bool setPhase2() { phase1=false; return true; }
+    void powerDownActive(bool active, bool startupOnly) { }
     
     // sets logic state for reverse motion
     void setReverseState(int reverseState) {


### PR DESCRIPTION
This fixes this compile-time error:

/home/loko/astro/OnStep/OnStep/OnStep.ino: In function 'void setup()':
OnStep:375:91: error: no matching function for call to 'focuserDC::powerDownActive(bool, bool)'
  375 |     foc1.powerDownActive(AXIS4_DRIVER_POWER_DOWN == ON, AXIS4_DRIVER_POWER_DOWN == STARTUP);
      |                                                                                           ^
In file included from /home/loko/astro/OnStep/OnStep/OnStep.ino:123:
sketch/src/lib/Focuser.h:69:18: note: candidate: 'virtual void focuser::powerDownActive(bool)'
   69 |     virtual void powerDownActive(bool active) { }
      |                  ^~~~~~~~~~~~~~~
sketch/src/lib/Focuser.h:69:18: note:   candidate expects 1 argument, 2 provided
exit status 1
no matching function for call to 'focuserDC::powerDownActive(bool, bool)'