### PR TITLE
Allow temperature updates when WEATHER is OFF

### DIFF
--- a/src/lib/Weather.h
+++ b/src/lib/Weather.h
@@ -190,8 +190,8 @@ class weather {
 
     // designed for a 0.01s polling interval, 5 seconds to refresh everything
     void poll() {
-      static bool firstScanDone = false;
 #if WEATHER != OFF || defined(ONEWIRE_DEVICES_PRESENT)
+      static bool firstScanDone = false;
       if (_BME280_found || _BMP280_found || _DS1820_found || _DS2413_found) {
 
         static int phase = 0;
@@ -279,8 +279,8 @@ class weather {
   #endif
       phase++;
       }
-#endif
       if (!firstScanDone) return;
+#endif
       
 #if TELESCOPE_TEMPERATURE == OFF
       // use primary temperature for the telescope temperature if TELESCOPE_TEMPERATURE


### PR DESCRIPTION
My JTW controller does not have a BME280 chip so WEATHER is set to OFF as such firstScanDone never flips and the code that averages out temperature updates is never run. this means that a :SX9A command does not update the temperature.

This allows for offline updates of weather parameters ( diffraction based tracking ) by an external process. for eg. read a weather station and update temperature, humidity and pressure by using the command channel with SX9 commands